### PR TITLE
Add multi-org verification, role sync, and config commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -64,10 +64,11 @@ This document lists all available commands for the SCANZ-BOT.
 
 ## Verification Commands
 *   **`/verify`** (Slash Command)
-    *   **Description**: Link your Discord account to your RSI Handle using a unique bio checksum.
-    *   **Usage**: `/verify handle:[Your_RSI_Handle]`
+    *   **Description**: Link your Discord account to your RSI Handle using a unique bio checksum. Optionally specify which organisation/affiliate you are verifying for.
+    *   **Usage**: `/verify handle:[Your_RSI_Handle] org:[ORG]`
     *   **Arguments**:
         *   `handle`: Your exact Star Citizen RSI Handle.
+        *   `org` *(Optional)*: Symbol of the organisation/affiliate (autocomplete supported).
     *   **Permission**: Everyone
 *   **`/set_verified_role`** (Slash Command)
     *   **Description**: Admin command to set the role granted upon successful RSI Verification.
@@ -75,6 +76,26 @@ This document lists all available commands for the SCANZ-BOT.
     *   **Arguments**:
         *   `role`: The role to grant verified users.
     *   **Permission**: Admin
+*   **`/set_scanz_role`**
+    *   **Description**: Admin command to configure the role that identifies SCANZ members (used for enforcement and audit tagging).
+    *   **Usage**: `/set_scanz_role role:@SCANZ`
+    *   **Permission**: Admin
+*   **`/set_needs_role`**
+    *   **Description**: Admin command to set the role that will be applied to members needing verification.
+    *   **Usage**: `/set_needs_role role:@NeedsVerification`
+    *   **Permission**: Admin
+*   **`/add_org`**
+    *   **Description**: Admin command to add an RSI organisation or affiliate symbol to the configuration.
+    *   **Usage**: `/add_org symbol:SCANZ`
+    *   **Permission**: Admin
+*   **`/remove_org`**
+    *   **Description**: Admin command to remove an organisation symbol.
+    *   **Usage**: `/remove_org symbol:SCANZ`
+    *   **Permission**: Admin
+*   **`/list_orgs`**
+    *   **Description**: Displays the currently configured organisation symbols.
+    *   **Usage**: `/list_orgs`
+    *   **Permission**: Everyone
 *   **`/grant_verified`** (Slash Command)
     *   **Description**: Admin shortcut to manually apply the verified role and RSI Handle nickname to an already-verified member.
     *   **Usage**: `/grant_verified member:@SomeUser`
@@ -82,11 +103,12 @@ This document lists all available commands for the SCANZ-BOT.
         *   `member`: The Discord member to apply the verified role and nickname to.
     *   **Permission**: Admin
 *   **`/manual_verify`** (Slash Command)
-    *   **Description**: Admin command to manually initiate the verification process for a member and an RSI handle. Generates a checksum challenge.
-    *   **Usage**: `/manual_verify member:@SomeUser handle:RSI_Handle`
+    *   **Description**: Admin command to manually initiate the verification process for a member and an RSI handle. Generates a checksum challenge. You may indicate which organisation this verification is for.
+    *   **Usage**: `/manual_verify member:@SomeUser handle:RSI_Handle org:[ORG]`
     *   **Arguments**:
         *   `member`: The Discord member to verify.
         *   `handle`: The RSI handle to link.
+        *   `org` *(Optional)*: Organisation symbol (autocomplete).
     *   **Permission**: Admin
 *   **`/export_verified`** (Slash Command)
     *   **Description**: Admin command to export the entire verification database as a CSV file.
@@ -101,13 +123,14 @@ This document lists all available commands for the SCANZ-BOT.
 
 ## Roster Monitor (Admin)
 *   **`/roster_audit`** (Slash Command)
-    *   **Description**: Manually triggers a check of all verified members to ensure they are still in the SCANZ organization on RSI.
+    *   **Description**: Manually triggers a check of all verified members (optionally limited by org) to ensure they are still active in their configured RSI organisation.
     *   **Permission**: Admin
 *   **`/set_roster_channel`** (Slash Command)
     *   **Description**: Sets the destination for weekly roster audit reports.
     *   **Permission**: Admin
 *   **`/org_full_sync`** (Slash Command)
-    *   **Description**: Admin command to perform a comprehensive sync between the RSI organization roster and the bot's verification database. Identifies unlinked RSI members.
+    *   **Description**: Admin command to perform a comprehensive sync between one or all RSI organisation rosters and the bot's verification database. Identifies unlinked RSI members.
+    *   **Usage**: `/org_full_sync org:[ORG]` (org parameter is optional)
     *   **Permission**: Admin
 
 ## Suggestion Box

--- a/cogs/message_enforcer.py
+++ b/cogs/message_enforcer.py
@@ -411,8 +411,18 @@ class MessageEnforcer(commands.Cog):
         # Resolve the target channel
         target_channel = await self._resolve_target_channel(interaction, channel)
 
-        # Ping logic - Fixed to @SCANZ role
-        scanz_role = discord.utils.get(interaction.guild.roles, name="SCANZ")
+        # Ping logic - retrieve configured role or fall back to name
+        def _get_scanz_role():
+            role_id = None
+            cog = self.bot.get_cog("RSIVerification")
+            if cog:
+                role_id = cog._get_config("scanz_role_id")
+            if role_id:
+                return interaction.guild.get_role(int(role_id))
+            # fallback to name
+            return discord.utils.get(interaction.guild.roles, name="SCANZ")
+
+        scanz_role = _get_scanz_role()
         mention_str = ""
 
         if scanz_role:
@@ -428,10 +438,8 @@ class MessageEnforcer(commands.Cog):
                 except discord.Forbidden:
                     pass  # Bot lacks permission to edit role
         else:
-            # Revert to a general message or error if the role is missing?
-            # The USER requested it be fixed to @SCANZ, so if it doesn't exist, we should probably warn.
             await interaction.response.send_message(
-                "❌ Error: Could not find the `@SCANZ` role in this server. Please contact an admin.",
+                "❌ Error: Could not find the SCANZ role in this server. Please contact an admin.",
                 ephemeral=True,
             )
             return

--- a/cogs/roster_monitor.py
+++ b/cogs/roster_monitor.py
@@ -13,18 +13,25 @@ class RosterMonitor(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.db_path = "data/enforcer.db"
-        self.org_handle = "SCANZ"  # The RSI Org handle to check for
+        # the list of organisations will be retrieved from the verification cog
         self.roster_check_loop.start()
 
     def cog_unload(self):
         self.roster_check_loop.cancel()
 
     def _get_verified_links(self):
-        """Fetch all discord_id to rsi_handle mappings."""
+        """Fetch all links including organisation info."""
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT discord_id, rsi_handle FROM rsi_links")
+            cursor.execute("SELECT discord_id, rsi_handle, org_handle FROM rsi_links")
             return cursor.fetchall()
+
+    async def org_autocomplete(self, interaction: discord.Interaction, current: str):
+        cog = self.bot.get_cog("RSIVerification")
+        if not cog:
+            return []
+        orgs = cog._get_orgs()
+        return [app_commands.Choice(name=o, value=o) for o in orgs if current.lower() in o.lower()]
 
     def _get_config(self, key: str) -> str:
         with sqlite3.connect(self.db_path) as conn:
@@ -39,8 +46,8 @@ class RosterMonitor(commands.Cog):
             cursor.execute("INSERT OR REPLACE INTO rsi_config (key, value) VALUES (?, ?)", (key, value))
             conn.commit()
 
-    async def _check_org_membership(self, handle: str) -> tuple[bool, str]:
-        """Scrape rsi profile to check if user is in the specified organization."""
+    async def _check_org_membership(self, handle: str, org: str) -> tuple[bool, str]:
+        """Scrape rsi profile to check if user is in the given organisation."""
         url = f"https://robertsspaceindustries.com/citizens/{handle}/organizations"
         async with aiohttp.ClientSession() as session:
             try:
@@ -54,20 +61,20 @@ class RosterMonitor(commands.Cog):
                     # Look for org links. Usually orgs are linked as /orgs/ORG_HANDLE
                     org_links = soup.find_all("a", href=True)
                     for link in org_links:
-                        if f"/orgs/{self.org_handle}".lower() in link["href"].lower():
+                        if f"/orgs/{org}".lower() in link["href"].lower():
                             return True, "Member"
 
                     return False, "Not in Org"
             except Exception as e:
                 return False, f"Error: {str(e)}"
 
-    async def _fetch_all_org_members(self) -> list[str]:
-        """Scrape the entire RSI organization roster and return a list of handles."""
+    async def _fetch_all_org_members(self, org: str) -> list[str]:
+        """Scrape the entire RSI organisation roster for a given org and return handles."""
         api_url = "https://robertsspaceindustries.com/api/orgs/getOrgMembers"
         headers = {
             "Content-Type": "application/json",
             "X-Requested-With": "XMLHttpRequest",
-            "Referer": f"https://robertsspaceindustries.com/orgs/{self.org_handle}/members",
+            "Referer": f"https://robertsspaceindustries.com/orgs/{org}/members",
         }
 
         handles = []
@@ -77,7 +84,7 @@ class RosterMonitor(commands.Cog):
         async with aiohttp.ClientSession(headers=headers) as session:
             while True:
                 payload = {
-                    "symbol": self.org_handle,
+                    "symbol": org,
                     "search": "",
                     "pagesize": page_size,
                     "page": page,
@@ -97,7 +104,6 @@ class RosterMonitor(commands.Cog):
                             break
 
                         soup = BeautifulSoup(html, "html.parser")
-                        # The subagent identified .nick as the handle container
                         nicks = soup.select(".nick")
                         if not nicks:
                             break
@@ -107,30 +113,27 @@ class RosterMonitor(commands.Cog):
                             if handle:
                                 handles.append(handle)
 
-                        # Check if we should continue
                         total_rows = data["data"].get("totalrows", 0)
                         if len(handles) >= total_rows:
                             break
 
                         page += 1
-                        # Mitigation for rate limits
                         await asyncio.sleep(1)
 
                 except Exception as e:
                     print(f"[RosterSync] Scraping exception: {e}")
                     break
 
-        return list(set(handles))  # Ensure uniqueness
+        return list(set(handles))
 
     @tasks.loop(hours=168)  # 1 week
     async def roster_check_loop(self):
-        """Weekly background task to audit the organization roster."""
-        # Wait until bot is ready
+        """Weekly background task to audit all configured organisations."""
         await self.bot.wait_until_ready()
         await self._run_audit()
 
     async def _run_audit(self, trigger_interaction: discord.Interaction = None):
-        """Execute the audit logic and notify admins."""
+        """Execute the audit logic and notify admins for each configured org."""
         target_channel_id = self._get_config("roster_audit_channel")
         if not target_channel_id:
             if trigger_interaction:
@@ -144,6 +147,21 @@ class RosterMonitor(commands.Cog):
             return
 
         verified_members = self._get_verified_links()
+        if trigger_interaction:
+            await trigger_interaction.followup.send("🔄 Syncing roles for guild members...")
+        # run role synchronization for everyone who has the SCANZ role; this will
+        # mark unverified members with the needs-verification role and clean up
+        # anyone who recently became verified.
+        cog = self.bot.get_cog("RSIVerification")
+        if cog:
+            scanz_role_id = cog._get_config("scanz_role_id")
+            if scanz_role_id:
+                scanz_role = target_channel.guild.get_role(int(scanz_role_id))
+                if scanz_role:
+                    for member in scanz_role.members:
+                        await cog.sync_member_roles(member)
+                        await asyncio.sleep(0.5)
+
         if not verified_members:
             if trigger_interaction:
                 await trigger_interaction.followup.send("No verified members found in database.")
@@ -151,21 +169,27 @@ class RosterMonitor(commands.Cog):
 
         if trigger_interaction:
             await trigger_interaction.followup.send(
-                f"🔍 Starting roster audit for {len(verified_members)} members..."
+                f"🔍 Starting roster audit for {len(verified_members)} entries..."
             )
 
         audit_results = []
-        for discord_id, handle in verified_members:
-            is_member, status = await self._check_org_membership(handle)
+        # loop through each stored entry; entries include org value
+        for discord_id, handle, org in verified_members:
+            # sync discord roles if possible
+            cog = self.bot.get_cog("RSIVerification")
+            member = target_channel.guild.get_member(discord_id)
+            if member and cog:
+                await cog.sync_member_roles(member)
+
+            is_member, status = await self._check_org_membership(handle, org)
             if not is_member:
-                audit_results.append((discord_id, handle, status))
-            # Rate limit mitigation
+                audit_results.append((discord_id, handle, org, status))
             await asyncio.sleep(2)
 
         if not audit_results:
             embed = discord.Embed(
                 title="Roster Audit: Clean",
-                description="✅ All verified members are still active in the SCANZ organization.",
+                description="✅ All verified members are still active in their configured organisations.",
                 color=discord.Color.green(),
                 timestamp=datetime.now(),
             )
@@ -174,16 +198,15 @@ class RosterMonitor(commands.Cog):
             embed = discord.Embed(
                 title="Roster Audit: Anomalies Found",
                 description=(
-                    f"⚠️ {len(audit_results)} members are no longer detected in the "
-                    f"**{self.org_handle}** organization.\n\nPlease review their roles manually."
+                    f"⚠️ {len(audit_results)} entries reference handles no longer detected in their org.\n\nPlease review their roles manually."
                 ),
                 color=discord.Color.red(),
                 timestamp=datetime.now(),
             )
 
             anomalies_str = ""
-            for d_id, handle, status in audit_results:
-                line = f"- <@{d_id}> (`{handle}`): {status}\n"
+            for d_id, handle, org, status in audit_results:
+                line = f"- <@{d_id}> (`{handle}` in {org}): {status}\n"
                 if len(anomalies_str) + len(line) > 1000:
                     embed.add_field(name="Anomaly List", value=anomalies_str, inline=False)
                     anomalies_str = line
@@ -193,7 +216,6 @@ class RosterMonitor(commands.Cog):
             if anomalies_str:
                 embed.add_field(name="Anomaly List", value=anomalies_str, inline=False)
 
-            # Optional: Ping admin role if configured
             admin_role_id = self._get_config("verified_role_id")
             content = f"<@&{admin_role_id}> Roster audit complete." if admin_role_id else None
 
@@ -223,48 +245,72 @@ class RosterMonitor(commands.Cog):
 
     @app_commands.command(
         name="org_full_sync",
-        description="Admin: Sync the entire RSI Org roster with the verification database.",
+        description="Admin: Sync one or all RSI Org rosters with the verification database.",
     )
+    @app_commands.describe(org="The organisation symbol to sync (optional)")
+    @app_commands.autocomplete(org="org_autocomplete")
     @app_commands.default_permissions(administrator=True)
-    async def org_full_sync(self, interaction: discord.Interaction):
-        """Perform a full synchronization check between RSI and Discord."""
+    async def org_full_sync(self, interaction: discord.Interaction, org: str = None):
+        """Perform a full synchronization check between RSI and Discord.
+
+        If `org` is provided we only sync that symbol; otherwise all configured orgs are scanned.
+        """
         await interaction.response.defer(ephemeral=True)
 
         verified_links = self._get_verified_links()
-        verified_handles = {h.lower() for _, h in verified_links}
+        verified_handles = {h.lower() for _, h, _ in verified_links}
 
-        await interaction.followup.send(
-            f"📥 Fetching all members from `{self.org_handle}` roster on RSI (this may take a minute)..."
-        )
+        # determine which org(s) to operate on
+        orgs = []
+        cog = self.bot.get_cog("RSIVerification")
+        if cog:
+            orgs = cog._get_orgs()
+        if org:
+            if org.upper() not in orgs:
+                await interaction.followup.send(
+                    f"❌ Unknown org `{org}`. Valid: {', '.join(orgs)}.", ephemeral=True
+                )
+                return
+            orgs = [org.upper()]
 
-        rsi_handles = await self._fetch_all_org_members()
-        if not rsi_handles:
-            await interaction.followup.send("❌ Error: Could not fetch members from RSI.", ephemeral=True)
+        if not orgs:
+            await interaction.followup.send("❌ No organisations configured.", ephemeral=True)
             return
 
+        await interaction.followup.send(
+            f"📥 Fetching members for {', '.join(orgs)} from RSI (this may take a minute)..."
+        )
+
         missing_from_db = []
-        for h in rsi_handles:
-            if h.lower() not in verified_handles:
-                missing_from_db.append(h)
+        for symbol in orgs:
+            rsi_handles = await self._fetch_all_org_members(symbol)
+            if not rsi_handles:
+                await interaction.followup.send(
+                    f"❌ Error: Could not fetch members from RSI for {symbol}.", ephemeral=True
+                )
+                continue
+
+            for h in rsi_handles:
+                if h.lower() not in verified_handles:
+                    missing_from_db.append((h, symbol))
 
         embed = discord.Embed(
-            title=f"Full Org Sync: {self.org_handle}",
-            description=(
-                f"Comparison complete between **{len(rsi_handles)}** RSI members "
-                f"and **{len(verified_handles)}** verified database entries."
-            ),
+            title="Full Org Sync",
+            description=("Comparison complete between RSI members and verified database entries."),
             color=discord.Color.blue(),
             timestamp=datetime.now(),
         )
 
-        # 1. Summary Stats
-        embed.add_field(name="RSI Members", value=str(len(rsi_handles)), inline=True)
-        embed.add_field(name="Verified Linked", value=str(len(verified_handles)), inline=True)
-        embed.add_field(name="Not Verified", value=str(len(missing_from_db)), inline=True)
+        stats = {symbol: 0 for symbol in orgs}
+        for _, symbol in missing_from_db:
+            stats[symbol] += 1
 
-        # 2. List Missing (Limit for Embed)
+        embed.add_field(
+            name="Unverified totals", value="\n".join(f"{s}: {stats[s]}" for s in stats), inline=False
+        )
+
         if missing_from_db:
-            missing_str = "\n".join([f"- `{h}`" for h in missing_from_db[:30]])
+            missing_str = "\n".join([f"- `{h}` ({sym})" for h, sym in missing_from_db[:30]])
             if len(missing_from_db) > 30:
                 missing_str += f"\n*...and {len(missing_from_db) - 30} more.*"
             embed.add_field(name="Unlinked RSI Members", value=missing_str, inline=False)

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -13,11 +13,12 @@ from discord.ext import commands
 
 
 class VerifyNowView(discord.ui.View):
-    def __init__(self, cog, handle: str, code: str):
+    def __init__(self, cog, handle: str, code: str, org: str | None = None):
         super().__init__(timeout=None)
         self.cog = cog
         self.handle = handle
         self.code = code
+        self.org = org
 
     @discord.ui.button(label="Verify Now", style=discord.ButtonStyle.success, emoji="✅")
     async def verify_button(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -27,10 +28,14 @@ class VerifyNowView(discord.ui.View):
 
         if success:
             # 1. Update database
+            target_org = self.org
+            # if scraping returned an org and user didn't specify one, use it
+            if not target_org and isinstance(message, dict):
+                target_org = message.get("org")
             self.cog._link_account(
                 interaction.user.id,
                 self.handle,
-                message.get("org", None) if isinstance(message, dict) else None,
+                target_org,
             )
 
             # Fetch the actual Member object from the guild (interaction.user is a User, not a Member)
@@ -48,20 +53,8 @@ class VerifyNowView(discord.ui.View):
                 # except discord.Forbidden:
                 #     print(f"[Verify] Forbidden: Could not set nickname for {member}")
 
-                # 3. Add Verified Role
-                role_id_str = self.cog._get_config("verified_role_id")
-                if role_id_str:
-                    verified_role = interaction.guild.get_role(int(role_id_str))
-                    if verified_role:
-                        try:
-                            await member.add_roles(verified_role)
-                        except discord.Forbidden:
-                            print(
-                                f"[Verify] Forbidden: Could not assign role '{verified_role.name}' "
-                                f"to {member}"
-                            )
-                    else:
-                        print(f"[Verify] Warning: Configured role ID '{role_id_str}' not found in guild.")
+                # 3. Add Verified Role (sync will also remove needs-role if present)
+                await self.cog.sync_member_roles(member)
 
             await interaction.followup.send(
                 f"✅ **Verification Successful!** Your Discord account is now officially linked to the "
@@ -81,19 +74,21 @@ class RSIVerification(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.db_path = "data/enforcer.db"
+        # in-memory cache of configured org symbols; loaded on demand
+        self._org_cache: list[str] | None = None
         self._setup_db()
 
     def _setup_db(self):
+        """Create or migrate the database schema.
+
+        The `rsi_links` table is rebuilt if necessary so that it contains the
+        composite primary key `(discord_id, org_handle)` and uses the
+        `org_handle` column name consistently.
+        """
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
-            cursor.execute("""
-                CREATE TABLE IF NOT EXISTS rsi_links (
-                    discord_id INTEGER PRIMARY KEY,
-                    rsi_handle TEXT NOT NULL,
-                    org TEXT
-                )
-            """)
+            # ensure config table exists
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS rsi_config (
                     key TEXT PRIMARY KEY,
@@ -101,12 +96,42 @@ class RSIVerification(commands.Cog):
                 )
             """)
 
-            # Check if org column exists, add it if not (migration)
+            # examine existing links schema
             cursor.execute("PRAGMA table_info(rsi_links)")
-            columns = [col[1] for col in cursor.fetchall()]
-            if "org" not in columns:
-                cursor.execute("ALTER TABLE rsi_links ADD COLUMN org TEXT")
+            cols = cursor.fetchall()
+            col_names = [c[1] for c in cols]
+            has_org_handle = "org_handle" in col_names
+            has_org = "org" in col_names
 
+            # if table missing or requires migration, rebuild it
+            if not cols or (has_org and not has_org_handle) or (cols and not has_org_handle):
+                # create a new table with desired schema
+                cursor.execute("""
+                    CREATE TABLE IF NOT EXISTS rsi_links_new (
+                        discord_id INTEGER,
+                        rsi_handle TEXT NOT NULL,
+                        org_handle TEXT NOT NULL DEFAULT 'SCANZ',
+                        PRIMARY KEY(discord_id, org_handle)
+                    )
+                """)
+                # copy existing data if any
+                if cols:
+                    # handle both old column names
+                    if has_org_handle:
+                        cursor.execute(
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, org_handle FROM rsi_links"
+                        )
+                    elif has_org:
+                        cursor.execute(
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, COALESCE(org, 'SCANZ') FROM rsi_links"
+                        )
+                    else:
+                        cursor.execute(
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, 'SCANZ' FROM rsi_links"
+                        )
+                # drop old table and rename
+                cursor.execute("DROP TABLE IF EXISTS rsi_links")
+                cursor.execute("ALTER TABLE rsi_links_new RENAME TO rsi_links")
             conn.commit()
 
     def _set_config(self, key: str, value: str):
@@ -128,23 +153,79 @@ class RSIVerification(commands.Cog):
             row = cursor.fetchone()
             return row[0] if row else None
 
-    def _is_verified(self, discord_id: int) -> str:
+    # -------------------------------------------------------------
+    # organisation helpers
+    # -------------------------------------------------------------
+    def _get_orgs(self) -> list[str]:
+        """Return the list of configured RSI organisation/affiliate symbols."""
+        if self._org_cache is not None:
+            return self._org_cache
+        val = self._get_config("org_handles")
+        if not val:
+            self._org_cache = []
+        else:
+            self._org_cache = [s.strip().upper() for s in val.split(",") if s.strip()]
+        return self._org_cache
+
+    def _add_org(self, org: str) -> bool:
+        """Add a symbol to the org list. Returns True if added."""
+        org = org.upper()
+        orgs = self._get_orgs()
+        if org in orgs:
+            return False
+        orgs.append(org)
+        self._set_config("org_handles", ",".join(orgs))
+        self._org_cache = orgs
+        return True
+
+    def _remove_org(self, org: str) -> bool:
+        """Remove a symbol from the org list. Returns True if removed."""
+        org = org.upper()
+        orgs = self._get_orgs()
+        if org not in orgs:
+            return False
+        orgs = [o for o in orgs if o != org]
+        self._set_config("org_handles", ",".join(orgs))
+        self._org_cache = orgs
+        return True
+
+    async def org_autocomplete(self, interaction: discord.Interaction, current: str):
+        """Autocomplete helper for organisation parameters."""
+        orgs = self._get_orgs()
+        return [app_commands.Choice(name=o, value=o) for o in orgs if current.lower() in o.lower()]
+
+    def _is_verified(self, discord_id: int, org: str = None) -> str:
+        """Return the linked RSI handle for the given discord ID.
+
+        If `org` is provided we restrict to that organisation, otherwise
+        we return the first matching handle regardless of org.
+        """
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT rsi_handle FROM rsi_links WHERE discord_id = ?", (discord_id,))
+            if org:
+                cursor.execute(
+                    "SELECT rsi_handle FROM rsi_links WHERE discord_id = ? AND org_handle = ?",
+                    (discord_id, org.upper()),
+                )
+            else:
+                cursor.execute(
+                    "SELECT rsi_handle FROM rsi_links WHERE discord_id = ?",
+                    (discord_id,),
+                )
             row = cursor.fetchone()
             return row[0] if row else None
 
     def _link_account(self, discord_id: int, handle: str, org: str = None):
+        # pick a default org if none supplied
+        if not org:
+            orgs = self._get_orgs()
+            org = orgs[0] if orgs else ""
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                INSERT INTO rsi_links (discord_id, rsi_handle, org)
+                INSERT OR REPLACE INTO rsi_links (discord_id, rsi_handle, org_handle)
                 VALUES (?, ?, ?)
-                ON CONFLICT(discord_id) DO UPDATE SET
-                    rsi_handle=excluded.rsi_handle,
-                    org=excluded.org
             """,
                 (discord_id, handle, org),
             )
@@ -190,25 +271,50 @@ class RSIVerification(commands.Cog):
             except Exception as e:
                 return False, f"Scraping error: {str(e)}"
 
-    def _generate_code(self) -> str:
-        # e.g., SCANZ-A7K9
+    def _generate_code(self, org: str) -> str:
+        # e.g., VER-SCANZ-A7K9 or just "VER-XXXX"; include org for clarity
         suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
-        return f"SCANZ-{suffix}"
+        # prefix with org symbol if available
+        return f"{org}-{suffix}" if org else f"VER-{suffix}"
 
     @app_commands.command(name="verify", description="Link your Discord account to your RSI Handle.")
     @app_commands.describe(handle="Your exact Star Citizen RSI Handle")
-    async def verify(self, interaction: discord.Interaction, handle: str):
-        # 1. Check if they are already verified
-        existing_handle = self._is_verified(interaction.user.id)
+    @app_commands.describe(org="The organisation/affiliate you belong to")
+    @app_commands.autocomplete(org="org_autocomplete")
+    async def verify(self, interaction: discord.Interaction, handle: str, org: str = None):
+        # ensure there is at least one configured org
+        orgs = self._get_orgs()
+        if not orgs:
+            await interaction.response.send_message(
+                "❌ No organisations configured. Please ask an administrator to add one.",
+                ephemeral=True,
+            )
+            return
+
+        # choose which org this verification is for
+        if org:
+            if org.upper() not in orgs:
+                await interaction.response.send_message(
+                    f"❌ Unknown organisation `{org}`. Valid choices: {', '.join(orgs)}.",
+                    ephemeral=True,
+                )
+                return
+            chosen_org = org.upper()
+        else:
+            # default to first configured org
+            chosen_org = orgs[0]
+
+        # 1. Check if they are already verified for this org
+        existing_handle = self._is_verified(interaction.user.id, chosen_org)
         if existing_handle:
             await interaction.response.send_message(
-                f"You are already verified and linked to the RSI Handle **{existing_handle}**.",
+                f"You are already verified for {chosen_org} and linked to the RSI Handle **{existing_handle}**.",
                 ephemeral=True,
             )
             return
 
         # 2. Generate a challenge code
-        code = self._generate_code()
+        code = self._generate_code(chosen_org)
 
         # 3. Present the challenge to the user
         embed = discord.Embed(
@@ -226,7 +332,7 @@ class RSIVerification(commands.Cog):
         embed.add_field(name="Your Unique Code", value=f"`{code}`", inline=False)
         embed.set_footer(text="You can remove the code from your bio once verification is successful.")
 
-        view = VerifyNowView(self, handle, code)
+        view = VerifyNowView(self, handle, code, org=chosen_org)
 
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
@@ -246,10 +352,29 @@ class RSIVerification(commands.Cog):
         description="Admin: Manually initiate verification for a specific member.",
     )
     @app_commands.describe(member="The Discord member", handle="The RSI Handle to link")
+    @app_commands.describe(org="Organisation symbol for this manual verification")
     @app_commands.default_permissions(administrator=True)
-    async def manual_verify(self, interaction: discord.Interaction, member: discord.Member, handle: str):
+    @app_commands.autocomplete(org="org_autocomplete")
+    async def manual_verify(
+        self, interaction: discord.Interaction, member: discord.Member, handle: str, org: str = None
+    ):
+        # Determine organisation for manual verification
+        orgs = self._get_orgs()
+        chosen_org = None
+        if org:
+            if org.upper() in orgs:
+                chosen_org = org.upper()
+            else:
+                await interaction.response.send_message(
+                    f"❌ Unknown organisation `{org}`. Valid: {', '.join(orgs)}.",
+                    ephemeral=True,
+                )
+                return
+        else:
+            chosen_org = orgs[0] if orgs else None
+
         # Generate challenge code
-        code = self._generate_code()
+        code = self._generate_code(chosen_org)
 
         embed = discord.Embed(
             title="Manual Verification Initiated",
@@ -265,12 +390,13 @@ class RSIVerification(commands.Cog):
 
         # Reusing VerifyNowView logic but adapted for manual flow
         class ManualVerifyView(discord.ui.View):
-            def __init__(self, cog, target_member, target_handle, target_code):
+            def __init__(self, cog, target_member, target_handle, target_code, target_org=None):
                 super().__init__(timeout=None)
                 self.cog = cog
                 self.member = target_member
                 self.handle = target_handle
                 self.code = target_code
+                self.org = target_org
 
             @discord.ui.button(label="Complete Verification", style=discord.ButtonStyle.success, emoji="✅")
             async def verify_button(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -278,21 +404,17 @@ class RSIVerification(commands.Cog):
                 success, message = await self.cog._scrape_rsi_bio(self.handle, self.code)
 
                 if success:
+                    target_org = self.org
+                    if not target_org and isinstance(message, dict):
+                        target_org = message.get("org")
                     self.cog._link_account(
                         self.member.id,
                         self.handle,
-                        message.get("org", None) if isinstance(message, dict) else None,
+                        target_org,
                     )
 
-                    # Grant role
-                    role_id_str = self.cog._get_config("verified_role_id")
-                    if role_id_str:
-                        role = interaction.guild.get_role(int(role_id_str))
-                        if role:
-                            try:
-                                await self.member.add_roles(role)
-                            except discord.Forbidden:
-                                pass
+                    # sync roles (will add verified role and remove needs-role)
+                    await self.cog.sync_member_roles(self.member)
 
                     await interaction.followup.send(
                         f"✅ Successfully verified and linked {self.member.mention} to `{self.handle}`.",
@@ -302,7 +424,8 @@ class RSIVerification(commands.Cog):
                 else:
                     await interaction.followup.send(f"❌ Verification failed: {message}", ephemeral=True)
 
-        view = ManualVerifyView(self, member, handle, code)
+        # create view with selected organisation and send once
+        view = ManualVerifyView(self, member, handle, code, target_org=chosen_org)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @app_commands.command(
@@ -315,7 +438,7 @@ class RSIVerification(commands.Cog):
 
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT discord_id, rsi_handle FROM rsi_links")
+            cursor.execute("SELECT discord_id, rsi_handle, org_handle FROM rsi_links")
             rows = cursor.fetchall()
 
         if not rows:
@@ -325,13 +448,13 @@ class RSIVerification(commands.Cog):
         # Use in-memory buffer for CSV
         output = io.StringIO()
         writer = csv.writer(output)
-        writer.writerow(["Discord ID", "Discord Name", "RSI Handle"])
+        writer.writerow(["Discord ID", "Discord Name", "RSI Handle", "Org"])
 
-        for discord_id, rsi_handle in rows:
+        for discord_id, rsi_handle, org in rows:
             # Try to resolve member name for readability in CSV
             member = interaction.guild.get_member(discord_id)
             name = f"{member.name}" if member else "Unknown/Left"
-            writer.writerow([discord_id, name, rsi_handle])
+            writer.writerow([discord_id, name, rsi_handle, org])
 
         output.seek(0)
         file = discord.File(io.BytesIO(output.getvalue().encode()), filename="verified_members.csv")
@@ -353,7 +476,7 @@ class RSIVerification(commands.Cog):
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT discord_id, rsi_handle FROM rsi_links WHERE rsi_handle LIKE ? OR discord_id = ?",
+                "SELECT discord_id, rsi_handle, org_handle FROM rsi_links WHERE rsi_handle LIKE ? OR discord_id = ?",
                 (f"%{query}%", clean_query if clean_query.isdigit() else 0),
             )
             rows = cursor.fetchall()
@@ -363,10 +486,10 @@ class RSIVerification(commands.Cog):
             return
 
         embed = discord.Embed(title="Verification Search Results", color=discord.Color.blue())
-        for discord_id, rsi_handle in rows[:10]:  # Limit to 10 for sanity
+        for discord_id, rsi_handle, org in rows[:10]:  # Limit to 10 for sanity
             member = interaction.guild.get_member(discord_id)
             mention = member.mention if member else f"ID: {discord_id} (Left Server)"
-            embed.add_field(name=rsi_handle, value=mention, inline=False)
+            embed.add_field(name=f"{rsi_handle} ({org})", value=mention, inline=False)
 
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
@@ -377,6 +500,7 @@ class RSIVerification(commands.Cog):
     @app_commands.describe(member="The Discord member to grant the verified role to.")
     @app_commands.default_permissions(administrator=True)
     async def grant_verified(self, interaction: discord.Interaction, member: discord.Member):
+        # allow grant to specify org? use any for now
         rsi_handle = self._is_verified(member.id)
         if not rsi_handle:
             await interaction.response.send_message(
@@ -406,6 +530,98 @@ class RSIVerification(commands.Cog):
         await interaction.response.send_message(
             f"**Grant Verified: {member.display_name}** (`{rsi_handle}`)\n" + "\n".join(messages),
             ephemeral=True,
+        )
+
+    # helper to sync a member's roles based on their verification state
+    async def sync_member_roles(self, member: discord.Member) -> None:
+        guild = member.guild
+        scanz_role = guild.get_role(int(self._get_config("scanz_role_id") or 0))
+        ver_role = guild.get_role(int(self._get_config("verified_role_id") or 0))
+        needs_role = guild.get_role(int(self._get_config("needs_role_id") or 0))
+
+        is_verified = bool(self._is_verified(member.id))
+        to_add, to_remove = [], []
+        if is_verified:
+            if ver_role and ver_role not in member.roles:
+                to_add.append(ver_role)
+            if needs_role and needs_role in member.roles:
+                to_remove.append(needs_role)
+        else:
+            if scanz_role and scanz_role in member.roles:
+                if needs_role and needs_role not in member.roles:
+                    to_add.append(needs_role)
+            else:
+                if needs_role and needs_role in member.roles:
+                    to_remove.append(needs_role)
+
+        if to_add:
+            try:
+                await member.add_roles(*to_add, reason="Verification sync")
+            except discord.Forbidden:
+                pass
+        if to_remove:
+            try:
+                await member.remove_roles(*to_remove, reason="Verification sync")
+            except discord.Forbidden:
+                pass
+
+    # configuration commands
+    @app_commands.command(name="add_org", description="Admin: add an RSI organisation/affiliate symbol")
+    @app_commands.describe(symbol="The RSI org symbol, e.g. SCANZ")
+    @app_commands.default_permissions(administrator=True)
+    async def add_org(self, interaction: discord.Interaction, symbol: str):
+        added = self._add_org(symbol)
+        if added:
+            await interaction.response.send_message(
+                f"✅ Added organisation `{symbol.upper()}`.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                f"ℹ️ `{symbol.upper()}` is already configured.", ephemeral=True
+            )
+
+    @app_commands.command(name="remove_org", description="Admin: remove an RSI organisation/affiliate symbol")
+    @app_commands.describe(symbol="The RSI org symbol to remove")
+    @app_commands.default_permissions(administrator=True)
+    async def remove_org(self, interaction: discord.Interaction, symbol: str):
+        removed = self._remove_org(symbol)
+        if removed:
+            await interaction.response.send_message(
+                f"✅ Removed organisation `{symbol.upper()}`.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                f"⚠️ `{symbol.upper()}` was not configured.", ephemeral=True
+            )
+
+    @app_commands.command(name="list_orgs", description="List configured RSI organisations/affiliates.")
+    async def list_orgs(self, interaction: discord.Interaction):
+        orgs = self._get_orgs()
+        if orgs:
+            await interaction.response.send_message(
+                "Configured organisations: " + ", ".join(orgs), ephemeral=True
+            )
+        else:
+            await interaction.response.send_message("No organisations have been added yet.", ephemeral=True)
+
+    @app_commands.command(
+        name="set_scanz_role", description="Admin: set the role that identifies SCANZ members."
+    )
+    @app_commands.describe(role="Role that members should have to trigger verification checks")
+    @app_commands.default_permissions(administrator=True)
+    async def set_scanz_role(self, interaction: discord.Interaction, role: discord.Role):
+        self._set_config("scanz_role_id", str(role.id))
+        await interaction.response.send_message(f"✅ SCANZ role set to {role.mention}.", ephemeral=True)
+
+    @app_commands.command(
+        name="set_needs_role", description="Admin: set role applied to users needing verification."
+    )
+    @app_commands.describe(role="Role to apply when a SCANZ member is not verified")
+    @app_commands.default_permissions(administrator=True)
+    async def set_needs_role(self, interaction: discord.Interaction, role: discord.Role):
+        self._set_config("needs_role_id", str(role.id))
+        await interaction.response.send_message(
+            f"✅ Needs-verification role set to {role.mention}.", ephemeral=True
         )
 
     @commands.Cog.listener()

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -27,7 +27,11 @@ class VerifyNowView(discord.ui.View):
 
         if success:
             # 1. Update database
-            self.cog._link_account(interaction.user.id, self.handle)
+            self.cog._link_account(
+                interaction.user.id,
+                self.handle,
+                message.get("org", None) if isinstance(message, dict) else None,
+            )
 
             # Fetch the actual Member object from the guild (interaction.user is a User, not a Member)
             member = interaction.guild.get_member(interaction.user.id)
@@ -86,7 +90,8 @@ class RSIVerification(commands.Cog):
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS rsi_links (
                     discord_id INTEGER PRIMARY KEY,
-                    rsi_handle TEXT NOT NULL
+                    rsi_handle TEXT NOT NULL,
+                    org TEXT
                 )
             """)
             cursor.execute("""
@@ -95,6 +100,13 @@ class RSIVerification(commands.Cog):
                     value TEXT
                 )
             """)
+
+            # Check if org column exists, add it if not (migration)
+            cursor.execute("PRAGMA table_info(rsi_links)")
+            columns = [col[1] for col in cursor.fetchall()]
+            if "org" not in columns:
+                cursor.execute("ALTER TABLE rsi_links ADD COLUMN org TEXT")
+
             conn.commit()
 
     def _set_config(self, key: str, value: str):
@@ -123,19 +135,22 @@ class RSIVerification(commands.Cog):
             row = cursor.fetchone()
             return row[0] if row else None
 
-    def _link_account(self, discord_id: int, handle: str):
+    def _link_account(self, discord_id: int, handle: str, org: str = None):
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                INSERT OR REPLACE INTO rsi_links (discord_id, rsi_handle)
-                VALUES (?, ?)
+                INSERT INTO rsi_links (discord_id, rsi_handle, org)
+                VALUES (?, ?, ?)
+                ON CONFLICT(discord_id) DO UPDATE SET
+                    rsi_handle=excluded.rsi_handle,
+                    org=excluded.org
             """,
-                (discord_id, handle),
+                (discord_id, handle, org),
             )
             conn.commit()
 
-    async def _scrape_rsi_bio(self, handle: str, code: str) -> tuple[bool, str]:
+    async def _scrape_rsi_bio(self, handle: str, code: str) -> tuple[bool, str | dict]:
         url = f"https://robertsspaceindustries.com/citizens/{handle}"
         async with aiohttp.ClientSession() as session:
             try:
@@ -152,16 +167,26 @@ class RSIVerification(commands.Cog):
                     value_divs = soup.find_all("div", class_="value")
 
                     bio_text = ""
+                    code_found = False
                     for div in value_divs:
                         text = div.get_text(strip=True)
                         if code in text:
-                            return True, "Code successfully validated against the bio!"
+                            code_found = True
+                            break
                         bio_text += " " + text
 
-                    return False, (
-                        "The code was not found in your Short Bio. Sometimes RSI caches profiles—"
-                        "wait a minute and try again."
-                    )
+                    if not code_found:
+                        return False, (
+                            "The code was not found in your Short Bio. Sometimes RSI caches profiles—"
+                            "wait a minute and try again."
+                        )
+
+                    # Extract main org if code is found
+                    org_link = soup.select_one(".main-org .info .entry .value a")
+                    org = org_link.text.strip() if org_link else None
+
+                    return True, {"message": "Code successfully validated against the bio!", "org": org}
+
             except Exception as e:
                 return False, f"Scraping error: {str(e)}"
 
@@ -253,7 +278,11 @@ class RSIVerification(commands.Cog):
                 success, message = await self.cog._scrape_rsi_bio(self.handle, self.code)
 
                 if success:
-                    self.cog._link_account(self.member.id, self.handle)
+                    self.cog._link_account(
+                        self.member.id,
+                        self.handle,
+                        message.get("org", None) if isinstance(message, dict) else None,
+                    )
 
                     # Grant role
                     role_id_str = self.cog._get_config("verified_role_id")


### PR DESCRIPTION
## What does this PR do?

-Added multi‑org support and stored symbols in rsi_config (org_handles).
-Migrated rsi_links to include org_handle (composite key) and preserved existing data.
-Added /add_org, /remove_org, /list_orgs, and org autocomplete for commands.

## Why is this change needed?

-Allow single users to be verified across multiple affiliates without collisions.
-Centralize role logic to ensure consistent assignment/removal across flows.
-Make orgs and role IDs configurable so admins can manage behavior without code changes.

## Related Issue

-CSV export now includes organisation column and no longer duplicates rows.
-Removed duplicate command responses and reduced ad‑hoc role assignments.
-message_enforcer now uses configured scanz_role_id instead of a hardcoded role name.

## Checklist

- [x ] I followed the project style
- [ x] I tested my changes
- [x ] I updated documentation if needed
