### PR TITLE
fix: make cog loading path robust to CWD changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,8 @@ class ScanzBot(commands.Bot):
 
     async def setup_hook(self):
         # Load cogs
-        for filename in os.listdir("./cogs"):
+        cogs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cogs")
+        for filename in os.listdir(cogs_dir):
             if filename.endswith(".py"):
                 await self.load_extension(f"cogs.{filename[:-3]}")
 


### PR DESCRIPTION
## Description

Fixes #13.

Currently, `cogs_dir` is hardcoded as `./cogs`, which may fail when `main.py` is executed from a different working directory (e.g. Docker, systemd, or path differences).

## Changes made
- Dynamically resolves the `cogs` directory path relative to the location of `main.py` using `os.path.dirname(os.path.abspath(__file__))`. This guarantees robust extension loading.

## Testing
Running the bot from a different CWD outside the root directory should no longer fail with FileNotFoundError for `./cogs`.