### PR TITLE
fix: use timezone-aware UTC timestamps for embed timestamps

### DIFF
--- a/cogs/roster_monitor.py
+++ b/cogs/roster_monitor.py
@@ -1,6 +1,6 @@
 import asyncio
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 
 import aiohttp
 import discord
@@ -192,7 +192,7 @@ class RosterMonitor(commands.Cog):
                 title="Roster Audit: Clean",
                 description="✅ All verified members are still active in their configured organisations.",
                 color=discord.Color.green(),
-                timestamp=datetime.now(),
+                timestamp=datetime.now(timezone.utc),
             )
             await target_channel.send(embed=embed)
         else:
@@ -202,7 +202,7 @@ class RosterMonitor(commands.Cog):
                     f"⚠️ {len(audit_results)} entries reference handles no longer detected in their org.\n\nPlease review their roles manually."
                 ),
                 color=discord.Color.red(),
-                timestamp=datetime.now(),
+                timestamp=datetime.now(timezone.utc),
             )
 
             anomalies_str = ""
@@ -299,7 +299,7 @@ class RosterMonitor(commands.Cog):
             title="Full Org Sync",
             description=("Comparison complete between RSI members and verified database entries."),
             color=discord.Color.blue(),
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
         )
 
         stats = {symbol: 0 for symbol in orgs}

--- a/cogs/suggestions.py
+++ b/cogs/suggestions.py
@@ -1,6 +1,6 @@
 import os
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone 
 
 import discord
 from discord import app_commands
@@ -74,7 +74,7 @@ class Suggestions(commands.Cog):
                 INSERT INTO suggestions_log (user_id, suggestion_text, anonymous, timestamp, thread_id)
                 VALUES (?, ?, ?, ?, ?)
             """,
-                (user_id, text, 1 if anonymous else 0, datetime.now().isoformat(), thread_id),
+                (user_id, text, 1 if anonymous else 0, datetime.now(timezone.utc).isoformat(), thread_id),
             )
             conn.commit()
 
@@ -121,7 +121,7 @@ class Suggestions(commands.Cog):
             title="New Suggestion",
             description=text,
             color=discord.Color.gold() if not anonymous else discord.Color.light_grey(),
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
         )
 
         if anonymous:
@@ -198,7 +198,7 @@ class Suggestions(commands.Cog):
                         f"**{message.guild.name}**."
                     ),
                     color=discord.Color.blue(),
-                    timestamp=datetime.now(),
+                    timestamp=datetime.now(timezone.utc),
                 )
                 embed.add_field(
                     name="Reply Content", value=message.content[:1024] or "*[Embed/Image]*", inline=False


### PR DESCRIPTION
## What does this PR do?
Updates `roster_monitor.py` and `suggestions.py` to use timezone-aware UTC timestamps (`datetime.now(timezone.utc)`) instead of naive local timestamps (`datetime.now()`) for Discord embed timestamps.

## Why is this change needed?
Naive timestamps from `datetime.now()` have no timezone info, which can cause inconsistencies when the bot runs across different regions or servers. Using UTC ensures timestamps are consistent and unambiguous for auditing and logging.

## Related Issue
Closes #19 

## Checklist
- [x] I followed the project style
- [x] I tested my changes
- [ ] I updated documentation if needed