### PR TITLE
fix: security, bugs, and lint cleanup from codebase review

### DIFF
--- a/cogs/message_enforcer.py
+++ b/cogs/message_enforcer.py
@@ -215,7 +215,7 @@ class MessageEnforcer(commands.Cog):
             )
             conn.commit()
 
-    def _get_post_target(self, guild_id: int) -> int:
+    def _get_post_target(self) -> int:
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute('SELECT channel_id FROM post_targets WHERE post_type = "Ping"')
@@ -228,7 +228,7 @@ class MessageEnforcer(commands.Cog):
         if explicit_channel:
             return explicit_channel
 
-        target_id = self._get_post_target(interaction.guild_id)
+        target_id = self._get_post_target()
         if target_id:
             channel = interaction.guild.get_channel(target_id)
             if channel:
@@ -336,7 +336,8 @@ class MessageEnforcer(commands.Cog):
         # Check if it might be a valid command from an old prefix (we want to encourage slash commands,
         # but discord handles slash without hitting on_message with content in the same way usually.
         # Regular messages hit this though.)
-        # If we really want ZERO non-bot messages, we just delete everything. The slash command responses come from the bot.
+        # If we really want ZERO non-bot messages, we just delete everything.
+        # The slash command responses come from the bot.
 
         try:
             # Delete the user's message
@@ -428,13 +429,13 @@ class MessageEnforcer(commands.Cog):
         if scanz_role:
             mention_str = scanz_role.mention
 
-            # Handle mentionability if bot has permissions
-            if not scanz_role.mentionable:
+            # Track original mentionability so we only reset if WE changed it
+            was_mentionable = scanz_role.mentionable
+            if not was_mentionable:
                 try:
                     await scanz_role.edit(
                         mentionable=True, reason=f"Pinging {scanz_role.name} role via /ping command"
                     )
-                    # We'll reset it after sending the message
                 except discord.Forbidden:
                     pass  # Bot lacks permission to edit role
         else:
@@ -448,21 +449,19 @@ class MessageEnforcer(commands.Cog):
         try:
             await target_channel.send(content=mention_str, embed=embed)
 
-            # Reset mentionability if we changed it
-            if scanz_role and mention_str != "":
-                # Wait a moment for Discord to process the ping
+            # Only reset mentionability if we were the one who enabled it
+            if scanz_role and not was_mentionable:
                 await asyncio.sleep(1)
                 try:
-                    # If we made it mentionable, turn it back off (best effort)
                     await scanz_role.edit(mentionable=False, reason="Resetting @SCANZ mentionability")
                 except discord.Forbidden:
                     pass
 
-            # Send an ephemeral confirmation in the original channel
+            # Always send an ephemeral confirmation — never re-post the embed via interaction
             if target_channel.id == interaction.channel_id:
-                # If it's the same channel, we just respond with the full embed.
-                # (Discord slash commands look best when the bot replies directly to the command)
-                await interaction.response.send_message(embed=embed)
+                await interaction.response.send_message(
+                    "✅ Your ping has been posted in this channel.", ephemeral=True
+                )
             else:
                 await interaction.response.send_message(
                     f"✅ Your post has been successfully published in {target_channel.mention}",

--- a/cogs/roster_monitor.py
+++ b/cogs/roster_monitor.py
@@ -165,7 +165,9 @@ class RosterMonitor(commands.Cog):
 
         if not verified_members:
             if trigger_interaction:
-                await trigger_interaction.followup.send("No verified members found in database.", ephemeral=True)
+                await trigger_interaction.followup.send(
+                    "No verified members found in database.", ephemeral=True
+                )
             return
 
         if trigger_interaction:
@@ -199,7 +201,8 @@ class RosterMonitor(commands.Cog):
             embed = discord.Embed(
                 title="Roster Audit: Anomalies Found",
                 description=(
-                    f"⚠️ {len(audit_results)} entries reference handles no longer detected in their org.\n\nPlease review their roles manually."
+                    f"⚠️ {len(audit_results)} entries reference handles no longer detected in their org.\n\n"
+                    "Please review their roles manually."
                 ),
                 color=discord.Color.red(),
                 timestamp=datetime.now(timezone.utc),
@@ -223,7 +226,9 @@ class RosterMonitor(commands.Cog):
             await target_channel.send(content=content, embed=embed)
 
         if trigger_interaction:
-            await trigger_interaction.followup.send("✅ Audit complete! Results sent to the audit channel.", ephemeral=True)
+            await trigger_interaction.followup.send(
+                "✅ Audit complete! Results sent to the audit channel.", ephemeral=True
+            )
 
     @app_commands.command(
         name="set_roster_channel", description="Admin: Set the channel for roster audit notifications."

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -126,15 +126,18 @@ class RSIVerification(commands.Cog):
                     # handle both old column names
                     if has_org_handle:
                         cursor.execute(
-                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, org_handle FROM rsi_links"
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle)"
+                            " SELECT discord_id, rsi_handle, org_handle FROM rsi_links"
                         )
                     elif has_org:
                         cursor.execute(
-                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, COALESCE(org, 'SCANZ') FROM rsi_links"
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle)"
+                            " SELECT discord_id, rsi_handle, COALESCE(org, 'SCANZ') FROM rsi_links"
                         )
                     else:
                         cursor.execute(
-                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle) SELECT discord_id, rsi_handle, 'SCANZ' FROM rsi_links"
+                            "INSERT OR IGNORE INTO rsi_links_new(discord_id, rsi_handle, org_handle)"
+                            " SELECT discord_id, rsi_handle, 'SCANZ' FROM rsi_links"
                         )
                 # drop old table and rename
                 cursor.execute("DROP TABLE IF EXISTS rsi_links")
@@ -310,7 +313,8 @@ class RSIVerification(commands.Cog):
         existing_handle = self._is_verified(interaction.user.id, chosen_org)
         if existing_handle:
             await interaction.response.send_message(
-                f"You are already verified for {chosen_org} and linked to the RSI Handle **{existing_handle}**.",
+                f"You are already verified for {chosen_org} and linked to the RSI Handle "
+                f"**{existing_handle}**.",
                 ephemeral=True,
             )
             return
@@ -478,7 +482,8 @@ class RSIVerification(commands.Cog):
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT discord_id, rsi_handle, org_handle FROM rsi_links WHERE rsi_handle LIKE ? OR discord_id = ?",
+                "SELECT discord_id, rsi_handle, org_handle FROM rsi_links"
+                " WHERE rsi_handle LIKE ? OR discord_id = ?",
                 (f"%{query}%", clean_query if clean_query.isdigit() else 0),
             )
             rows = cursor.fetchall()

--- a/deploy/webhook_listener.py
+++ b/deploy/webhook_listener.py
@@ -1,53 +1,76 @@
-import subprocess
-import hmac
 import hashlib
+import hmac
 import os
-import json
-from flask import Flask, request, jsonify
+import subprocess
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+
+load_dotenv()
 
 app = Flask(__name__)
 
 # --- CONFIGURATION ---
-GITHUB_SECRET = os.environ.get("GITHUB_SECRET", "YOUR_OPENSSL_GENERATED_SECRET")
+# Load secret from environment variable — fail immediately if unset
+GITHUB_SECRET = os.environ.get("GITHUB_SECRET")
+if not GITHUB_SECRET:
+    raise RuntimeError("GITHUB_SECRET environment variable is not set. Refusing to start.")
 UPDATE_SCRIPT = "/opt/discord-bots/update.sh"
 BOT_DIR = "/opt/discord-bots/my-bot"
 # ---------------------
 
+
 def verify_signature(payload_body, secret_token, signature_header):
-    if not signature_header: return False
-    hash_object = hmac.new(secret_token.encode('utf-8'), msg=payload_body, digestmod=hashlib.sha256)
+    if not signature_header:
+        return False
+    hash_object = hmac.new(secret_token.encode("utf-8"), msg=payload_body, digestmod=hashlib.sha256)
     expected_signature = "sha256=" + hash_object.hexdigest()
     return hmac.compare_digest(expected_signature, signature_header)
+
 
 def get_current_branch():
     try:
         # Runs 'git rev-parse --abbrev-ref HEAD' to get the current branch of the repo
-        result = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], 
-                                cwd=BOT_DIR, capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=BOT_DIR,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
         print(f"Error getting current branch: {e}")
-        return "main" # Fallback
+        return "main"  # Fallback
 
-@app.route('/deploy', methods=['POST'])
+
+@app.route("/deploy", methods=["POST"])
 def deploy():
     # 1. Verify Signature
-    signature = request.headers.get('X-Hub-Signature-256')
+    signature = request.headers.get("X-Hub-Signature-256")
     if not verify_signature(request.data, GITHUB_SECRET, signature):
         return jsonify({"message": "Invalid signature"}), 403
 
     # 2. Extract Branch from Payload
     payload = request.json
-    pushed_ref = payload.get('ref', '')
-    
+    pushed_ref = payload.get("ref", "")
+
     # 3. Smart Branch Checking
     current_branch = get_current_branch()
     expected_ref = f"refs/heads/{current_branch}"
-    
+
     if pushed_ref != expected_ref:
-        return jsonify({
-            "message": f"Push event ignored. Server is tracking '{current_branch}', but received push for '{pushed_ref}'."
-        }), 200
+        return (
+            jsonify(
+                {
+                    "message": (
+                        f"Push event ignored. Server is tracking '{current_branch}', "
+                        f"but received push for '{pushed_ref}'."
+                    )
+                }
+            ),
+            200,
+        )
 
     # 4. Trigger Deployment
     try:
@@ -56,5 +79,6 @@ def deploy():
     except Exception as e:
         return jsonify({"message": str(e)}), 500
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,19 @@
 [tool.ruff]
-# Enable pycodestyle (E) and Pyflakes (F) codes by default.
-select = ["E", "F", "I"]
-ignore = []
-
-# Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
-
 # Increased for better readability on modern screens.
 line-length = 110
 indent-width = 4
+
+[tool.ruff.lint]
+# Enable pycodestyle (E), Pyflakes (F), and isort (I) rules.
+select = ["E", "F", "I"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix` is provided).
+fixable = ["ALL"]
+unfixable = []
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/tests/test_reaction_roles.py
+++ b/tests/test_reaction_roles.py
@@ -1,0 +1,346 @@
+"""
+Tests for cogs/reaction_roles.py
+Covers:
+  - Issue #16 fix: setup_reaction_role has @app_commands.default_permissions(manage_roles=True)
+  - DB initialisation (_setup_db) and restore (_load_from_db)
+  - setup_reaction_role command persists mapping in memory and SQLite
+  - on_raw_reaction_add assigns roles, skips bots, ignores unknown messages/emojis
+  - on_raw_reaction_remove removes roles, skips bots, ignores unknown messages/emojis
+"""
+
+import os
+import sqlite3
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord import app_commands
+
+# Make sure the project root is importable regardless of where pytest is run.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cogs.reaction_roles import ReactionRoles  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers / Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cog(tmp_path):
+    """
+    Return a ReactionRoles cog instance backed by a temporary SQLite database.
+
+    We bypass __init__ so we can point db_path at a safe temp directory without
+    touching the real 'data/' folder.
+    """
+    bot = MagicMock()
+    instance = ReactionRoles.__new__(ReactionRoles)
+    instance.bot = bot
+    instance.db_path = str(tmp_path / "reaction_roles.db")
+    instance.reaction_roles = {}
+    instance._setup_db()
+    instance._load_from_db()
+    return instance
+
+
+def _payload(message_id: int, emoji_str: str, guild_id: int = 1, user_id: int = 2) -> MagicMock:
+    """Return a minimal RawReactionActionEvent-style payload mock."""
+    p = MagicMock()
+    p.message_id = message_id
+    p.guild_id = guild_id
+    p.user_id = user_id
+    # str(payload.emoji) must return the emoji string.
+    p.emoji.__str__ = MagicMock(return_value=emoji_str)
+    return p
+
+
+def _member(*, is_bot: bool = False) -> MagicMock:
+    """Return a minimal Member mock."""
+    m = MagicMock()
+    m.bot = is_bot
+    m.add_roles = AsyncMock()
+    m.remove_roles = AsyncMock()
+    return m
+
+
+def _guild(role: MagicMock, member: MagicMock) -> MagicMock:
+    """Return a minimal Guild mock wired to the given role and member."""
+    g = MagicMock()
+    g.get_role.return_value = role
+    g.get_member.return_value = member
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Issue #16 — permission decorator
+# ---------------------------------------------------------------------------
+
+
+class TestPermissions:
+    def test_command_is_app_command(self):
+        """setup_reaction_role must be registered as an app_commands.Command."""
+        assert isinstance(ReactionRoles.setup_reaction_role, app_commands.Command)
+
+    def test_default_permissions_is_set(self):
+        """setup_reaction_role must declare default_permissions (issue #16)."""
+        cmd = ReactionRoles.setup_reaction_role
+        assert cmd.default_permissions is not None, (
+            "default_permissions is None — the @app_commands.default_permissions "
+            "decorator is missing (issue #16)"
+        )
+
+    def test_manage_roles_required(self):
+        """default_permissions must require manage_roles=True."""
+        perms = ReactionRoles.setup_reaction_role.default_permissions
+        assert perms is not None, "default_permissions is None — cannot check manage_roles"
+        assert perms.manage_roles is True, (
+            "manage_roles is not True — any user can invoke /setup_reaction_role"
+        )
+
+    def test_administrator_not_required(self):
+        """
+        We chose manage_roles over administrator (least-privilege).
+        If someone switches to administrator=True this test should be updated
+        intentionally, not silently.
+        """
+        perms = ReactionRoles.setup_reaction_role.default_permissions
+        assert perms is not None, "default_permissions is None — cannot check administrator"
+        assert perms.administrator is False, (
+            "Prefer manage_roles over administrator to follow least-privilege principle"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDatabase:
+    def test_setup_db_creates_table(self, cog):
+        """_setup_db() must create the reaction_roles table."""
+        with sqlite3.connect(cog.db_path) as conn:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='reaction_roles'"
+            ).fetchone()
+        assert row is not None, "Table 'reaction_roles' was not created"
+
+    def test_load_from_db_single_row(self, cog):
+        """_load_from_db() must restore a single emoji→role mapping."""
+        with sqlite3.connect(cog.db_path) as conn:
+            conn.execute("INSERT INTO reaction_roles VALUES (?, ?, ?)", (12345, "👍", 67890))
+            conn.commit()
+
+        cog.reaction_roles = {}
+        cog._load_from_db()
+
+        assert cog.reaction_roles.get(12345, {}).get("👍") == 67890
+
+    def test_load_from_db_multiple_rows(self, cog):
+        """_load_from_db() must handle multiple message/emoji pairs."""
+        rows = [(1, "👍", 100), (1, "👎", 200), (2, "🎉", 300)]
+        with sqlite3.connect(cog.db_path) as conn:
+            conn.executemany("INSERT INTO reaction_roles VALUES (?, ?, ?)", rows)
+            conn.commit()
+
+        cog.reaction_roles = {}
+        cog._load_from_db()
+
+        assert cog.reaction_roles[1]["👍"] == 100
+        assert cog.reaction_roles[1]["👎"] == 200
+        assert cog.reaction_roles[2]["🎉"] == 300
+
+    def test_load_from_db_empty(self, cog):
+        """_load_from_db() on an empty DB must leave reaction_roles empty."""
+        cog._load_from_db()
+        assert cog.reaction_roles == {}
+
+
+# ---------------------------------------------------------------------------
+# setup_reaction_role command
+# ---------------------------------------------------------------------------
+
+
+class TestSetupReactionRole:
+    def _make_interaction(self, msg_id: int = 99999) -> MagicMock:
+        interaction = MagicMock()
+        interaction.response.send_message = AsyncMock()
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.add_reaction = AsyncMock()
+        interaction.original_response = AsyncMock(return_value=msg)
+        return interaction
+
+    def _make_role(self, role_id: int = 111) -> MagicMock:
+        role = MagicMock(spec=discord.Role)
+        role.id = role_id
+        role.mention = f"<@&{role_id}>"
+        return role
+
+    async def test_stores_mapping_in_memory(self, cog):
+        """Command must write the emoji→role_id mapping to self.reaction_roles."""
+        interaction = self._make_interaction(msg_id=10001)
+        role = self._make_role(role_id=555)
+
+        await cog.setup_reaction_role.callback(cog, interaction, role, "👍", "React for role!")
+
+        assert cog.reaction_roles.get(10001, {}).get("👍") == 555
+
+    async def test_stores_mapping_in_db(self, cog):
+        """Command must persist the mapping to the SQLite database."""
+        interaction = self._make_interaction(msg_id=10002)
+        role = self._make_role(role_id=666)
+
+        await cog.setup_reaction_role.callback(cog, interaction, role, "🎉", "Party role!")
+
+        with sqlite3.connect(cog.db_path) as conn:
+            row = conn.execute(
+                "SELECT role_id FROM reaction_roles WHERE message_id=? AND emoji=?",
+                (10002, "🎉"),
+            ).fetchone()
+        assert row is not None and row[0] == 666
+
+    async def test_adds_reaction_to_message(self, cog):
+        """Command must add the emoji reaction to the posted embed message."""
+        interaction = self._make_interaction(msg_id=10003)
+        role = self._make_role()
+
+        await cog.setup_reaction_role.callback(cog, interaction, role, "⭐", "Star role!")
+
+        msg = await interaction.original_response()
+        msg.add_reaction.assert_called_once_with("⭐")
+
+    async def test_upsert_overwrites_existing_role(self, cog):
+        """Calling the command twice for the same message+emoji must overwrite."""
+        interaction1 = self._make_interaction(msg_id=10004)
+        interaction2 = self._make_interaction(msg_id=10004)
+        role_a = self._make_role(role_id=10)
+        role_b = self._make_role(role_id=20)
+
+        await cog.setup_reaction_role.callback(cog, interaction1, role_a, "👍", "First")
+        await cog.setup_reaction_role.callback(cog, interaction2, role_b, "👍", "Second")
+
+        assert cog.reaction_roles[10004]["👍"] == 20
+
+        with sqlite3.connect(cog.db_path) as conn:
+            row = conn.execute(
+                "SELECT role_id FROM reaction_roles WHERE message_id=? AND emoji=?",
+                (10004, "👍"),
+            ).fetchone()
+        assert row[0] == 20
+
+
+# ---------------------------------------------------------------------------
+# on_raw_reaction_add
+# ---------------------------------------------------------------------------
+
+
+class TestOnRawReactionAdd:
+    async def test_assigns_role_to_human_member(self, cog):
+        """Reaction add must assign the mapped role to a non-bot member."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        member = _member(is_bot=False)
+        role = MagicMock()
+        cog.bot.get_guild.return_value = _guild(role, member)
+
+        await cog.on_raw_reaction_add(_payload(12345, "👍"))
+
+        member.add_roles.assert_called_once_with(role)
+
+    async def test_skips_bot_members(self, cog):
+        """Reaction add must not assign roles to bot accounts."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        member = _member(is_bot=True)
+        role = MagicMock()
+        cog.bot.get_guild.return_value = _guild(role, member)
+
+        await cog.on_raw_reaction_add(_payload(12345, "👍"))
+
+        member.add_roles.assert_not_called()
+
+    async def test_ignores_untracked_message(self, cog):
+        """Reaction add on a message not in reaction_roles must be a no-op."""
+        cog.reaction_roles = {}
+
+        await cog.on_raw_reaction_add(_payload(99999, "👍"))
+
+        cog.bot.get_guild.assert_not_called()
+
+    async def test_ignores_untracked_emoji(self, cog):
+        """Reaction add with an emoji not in the mapping must be a no-op."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        await cog.on_raw_reaction_add(_payload(12345, "❌"))
+
+        cog.bot.get_guild.assert_not_called()
+
+    async def test_handles_deleted_role(self, cog):
+        """Reaction add must not raise if the role no longer exists in the guild."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        guild = MagicMock()
+        guild.get_role.return_value = None  # role was deleted
+        cog.bot.get_guild.return_value = guild
+
+        # Should complete without raising
+        await cog.on_raw_reaction_add(_payload(12345, "👍"))
+
+
+# ---------------------------------------------------------------------------
+# on_raw_reaction_remove
+# ---------------------------------------------------------------------------
+
+
+class TestOnRawReactionRemove:
+    async def test_removes_role_from_human_member(self, cog):
+        """Reaction remove must strip the mapped role from a non-bot member."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        member = _member(is_bot=False)
+        role = MagicMock()
+        cog.bot.get_guild.return_value = _guild(role, member)
+
+        await cog.on_raw_reaction_remove(_payload(12345, "👍"))
+
+        member.remove_roles.assert_called_once_with(role)
+
+    async def test_skips_bot_members(self, cog):
+        """Reaction remove must not strip roles from bot accounts."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        member = _member(is_bot=True)
+        role = MagicMock()
+        cog.bot.get_guild.return_value = _guild(role, member)
+
+        await cog.on_raw_reaction_remove(_payload(12345, "👍"))
+
+        member.remove_roles.assert_not_called()
+
+    async def test_ignores_untracked_message(self, cog):
+        """Reaction remove on an untracked message must be a no-op."""
+        cog.reaction_roles = {}
+
+        await cog.on_raw_reaction_remove(_payload(99999, "👍"))
+
+        cog.bot.get_guild.assert_not_called()
+
+    async def test_ignores_untracked_emoji(self, cog):
+        """Reaction remove with an untracked emoji must be a no-op."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        await cog.on_raw_reaction_remove(_payload(12345, "❌"))
+
+        cog.bot.get_guild.assert_not_called()
+
+    async def test_handles_deleted_role(self, cog):
+        """Reaction remove must not raise if the role no longer exists."""
+        cog.reaction_roles = {12345: {"👍": 67890}}
+
+        guild = MagicMock()
+        guild.get_role.return_value = None
+        cog.bot.get_guild.return_value = guild
+
+        await cog.on_raw_reaction_remove(_payload(12345, "👍"))

--- a/webhook_listener.py
+++ b/webhook_listener.py
@@ -11,20 +11,25 @@ load_dotenv()
 app = Flask(__name__)
 
 # --- CONFIGURATION ---
-# Load secret from environment variable for security
-GITHUB_SECRET = os.getenv("GITHUB_SECRET", "YOUR_OPENSSL_GENERATED_SECRET")
+# Load secret from environment variable for security — fail immediately if unset
+GITHUB_SECRET = os.getenv("GITHUB_SECRET")
+if not GITHUB_SECRET:
+    raise RuntimeError("GITHUB_SECRET environment variable is not set. Refusing to start.")
 UPDATE_SCRIPT = "/opt/discord-bots/update.sh"
 # ---------------------
 
+
 def verify_signature(payload_body, secret_token, signature_header):
-    if not signature_header: return False
-    hash_object = hmac.new(secret_token.encode('utf-8'), msg=payload_body, digestmod=hashlib.sha256)
+    if not signature_header:
+        return False
+    hash_object = hmac.new(secret_token.encode("utf-8"), msg=payload_body, digestmod=hashlib.sha256)
     expected_signature = "sha256=" + hash_object.hexdigest()
     return hmac.compare_digest(expected_signature, signature_header)
 
-@app.route('/deploy', methods=['POST'])
+
+@app.route("/deploy", methods=["POST"])
 def deploy():
-    signature = request.headers.get('X-Hub-Signature-256')
+    signature = request.headers.get("X-Hub-Signature-256")
     if not verify_signature(request.data, GITHUB_SECRET, signature):
         return jsonify({"message": "Invalid signature"}), 403
 
@@ -34,5 +39,6 @@ def deploy():
     except Exception as e:
         return jsonify({"message": str(e)}), 500
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## What does this PR do?

Github secrets for webhook deployment changes to ensure refusal to run in an insecure state. 
- Double-embed on same channel ping changes, to short ephemeral confirmation 
- incorrect mentionability reset from unconditional set to mentionable=false
- removed guild_id as it was unused will revisit if need in future
-  misc line length violations 

## Why is this change needed?

Explain the reasoning.

## Related Issue

Closes #12 

## Checklist

- [x] I followed the project style
- [x] I tested my changes
- [ ] I updated documentation if needed