### PR TITLE
Fix/defaultPerms

### DIFF
--- a/cogs/reaction_roles.py
+++ b/cogs/reaction_roles.py
@@ -39,6 +39,7 @@ class ReactionRoles(commands.Cog):
                 self.reaction_roles[msg_id][emoji] = role_id
 
     @app_commands.command(name="setup_reaction_role", description="Setup a reaction role message")
+    @app_commands.default_permissions(manage_roles=True)
     @app_commands.describe(
         role="The role to assign", emoji="The emoji to react with", message="Message content"
     )

--- a/cogs/suggestions.py
+++ b/cogs/suggestions.py
@@ -1,6 +1,6 @@
 import os
 import sqlite3
-from datetime import datetime, timezone 
+from datetime import datetime, timezone
 
 import discord
 from discord import app_commands

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0


### PR DESCRIPTION
## What does this PR do?

Update reaction roles defaults from admin to manage roles

## Why is this change needed?

to explicitly use the mange role prem to prevent unintended role behavour 

## Related Issue

Closes #16

## Checklist

- [x] I followed the project style
- [x] I tested my changes
- [x] I updated documentation if needed
