### PR TITLE
Staff role and command permissions

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -2,168 +2,199 @@
 
 This document lists all available commands for the SCANZ-BOT.
 
+## Permission Levels
+
+- **Everyone** – Any member can use the command.
+- **Manage Roles** – User must have the *Manage Roles* permission (or Administrator).
+- **Staff** – User must have the **Staff role** (configured via `/set_staff_role`) **or** *Administrator*. If no staff role is set, only *Administrator* can use these commands.
+- **Administrator** – User must have the *Administrator* permission. Used only for commands that configure who gets Staff access.
+
 ## General Commands
-*   **`!hi`**
-    *   **Description**: Says hello with a random strange/verbose message.
-    *   **Usage**: `!hi`
-    *   **Permission**: Everyone
-*   **`!time`**
-    *   **Description**: Displays the current time across major SCANZ timezones (Indochina, Perth, Melbourne/Sydney, New Zealand).
-    *   **Usage**: `!time`
-    *   **Permission**: Everyone
-*   **`@SCANZ_BOT [message]`**
-    *   **Description**: The bot will intelligently reply to keyword mentions (e.g. "website", "discord", "help") and fallback to random witty responses.
-    *   **Usage**: Tag `@SCANZ_BOT` anywhere in a channel.
-    *   **Permission**: Everyone
-*   **`/scanz_commands`** (Slash Command)
-    *   **Description**: Lists all available commands for the bot directly in an ephemeral Discord embed.
-    *   **Usage**: `/scanz_commands`
-    *   **Permission**: Everyone
+
+- `**!hi**`
+  - **Description**: Says hello with a random strange/verbose message.
+  - **Usage**: `!hi`
+  - **Permission**: Everyone
+- `**!time`**
+  - **Description**: Displays the current time across major SCANZ timezones (Indochina, Perth, Melbourne/Sydney, New Zealand).
+  - **Usage**: `!time`
+  - **Permission**: Everyone
+- `**@SCANZ_BOT [message]`**
+  - **Description**: The bot will intelligently reply to keyword mentions (e.g. "website", "discord", "help") and fallback to random witty responses.
+  - **Usage**: Tag `@SCANZ_BOT` anywhere in a channel.
+  - **Permission**: Everyone
+- `**/scanz_commands`** (Slash Command)
+  - **Description**: Lists all available commands for the bot directly in an ephemeral Discord embed.
+  - **Usage**: `/scanz_commands`
+  - **Permission**: Everyone
 
 ## Reaction Roles
-*   **`/setup_reaction_role`** (Slash Command)
-    *   **Description**: Creates a message with a specific reaction that assigns a role when clicked.
-    *   **Usage**: `/setup_reaction_role role:@Role emoji:👍 message:"Click to get role!"`
-    *   **Arguments**:
-        *   `role`: The role to give/remove.
-        *   `emoji`: The emoji to react with.
-        *   `message`: The text content of the embed.
-    *   **Permission**: Admin / Manage Roles (Implicit in Discord permissions)
+
+- `**/setup_reaction_role`** (Slash Command)
+  - **Description**: Creates a message with a specific reaction that assigns a role when clicked.
+  - **Usage**: `/setup_reaction_role role:@Role emoji:👍 message:"Click to get role!"`
+  - **Arguments**:
+    - `role`: The role to give/remove.
+    - `emoji`: The emoji to react with.
+    - `message`: The text content of the embed.
+  - **Permission**: Manage Roles
 
 ## Message Enforcement (Slash Commands)
-*   **`/enforce_channel`**
-    *   **Description**: Admin command to toggle strict message enforcement (Event/Ping/Announcement format only) for the current channel.
-    *   **Usage**: `/enforce_channel enabled:True`
-    *   **Arguments**:
-        *   `enabled`: True to enable, False to disable.
-    *   **Permission**: Admin
-*   **`/scanz_format`**
-    *   **Description**: Admin command to interactively set the allowed "Post Types" and "Game Loops" for an enforced channel. Posts an informational embed when saved.
-    *   **Usage**: `/scanz_format`
-    *   **Permission**: Admin
-*   **`/set_post_target`**
-    *   **Description**: Admin command to set a default designated target channel for a specific post type (e.g., all `EVENT` posts automatically route to `#org-events`).
-    *   **Usage**: `/set_post_target type:EVENT channel:#org-events`
-    *   **Permission**: Admin
-*   **`/scanz_subscriptions`**
-    *   **Description**: Admin command to post a persistent message with buttons for members to subscribe/unsubscribe from ping roles.
-    *   **Usage**: `/scanz_subscriptions`
-    *   **Permission**: Admin
-*   **`/ping`**
-    *   **Description**: Creates a formatted alert/ping. This command automatically pings the `@SCANZ` role.
-    *   **Usage**: `/ping game_loop:"Org Event" description:"QV RUN IN NYX" time:"1:00pm Melbourne" location:"Nyx" requirements:"Armour, Weapons, Meds" channel:#org-events`
-    *   **Arguments**:
-        *   `game_loop`: Select the type of activity (e.g., Mining, Bounties, Org Event).
-        *   `description`: What are we doing?
-        *   `time` *(Optional)*: When is it happening?
-        *   `location` *(Optional)*: Where is it starting?
-        *   `requirements` *(Optional)*: What should people bring?
-        *   `link` *(Optional)*: Link to a voice channel or event page.
-        *   `channel` *(Optional)*: Specifically pick an enforced channel to cross-post to. If left blank, falls back to the database-configured default for "Ping" or the current channel.
-    *   **Permission**: Everyone
+
+- `**/enforce_channel`**
+  - **Description**: Toggle strict message enforcement (Event/Ping/Announcement format only) for the current channel.
+  - **Usage**: `/enforce_channel enabled:True`
+  - **Arguments**:
+    - `enabled`: True to enable, False to disable.
+  - **Permission**: Staff
+- `**/scanz_format`**
+  - **Description**: Interactively set the allowed "Post Types" and "Game Loops" for an enforced channel. Posts an informational embed when saved.
+  - **Usage**: `/scanz_format`
+  - **Permission**: Staff
+- `**/set_ping_target`**
+  - **Description**: Set the default target channel for ping posts (e.g. all pings from this context route to `#org-events`).
+  - **Usage**: `/set_ping_target channel:#org-events`
+  - **Permission**: Staff
+- `**/scanz_subscriptions`**
+  - **Description**: Post a persistent message with buttons for members to subscribe/unsubscribe from ping roles.
+  - **Usage**: `/scanz_subscriptions`
+  - **Permission**: Staff
+- `**/ping`**
+  - **Description**: Creates a formatted alert/ping. This command automatically pings the `@SCANZ` role.
+  - **Usage**: `/ping game_loop:"Org Event" description:"QV RUN IN NYX" time:"1:00pm Melbourne" location:"Nyx" requirements:"Armour, Weapons, Meds" channel:#org-events`
+  - **Arguments**:
+    - `game_loop`: Select the type of activity (e.g., Mining, Bounties, Org Event).
+    - `description`: What are we doing?
+    - `time` *(Optional)*: When is it happening?
+    - `location` *(Optional)*: Where is it starting?
+    - `requirements` *(Optional)*: What should people bring?
+    - `link` *(Optional)*: Link to a voice channel or event page.
+    - `channel` *(Optional)*: Specifically pick an enforced channel to cross-post to. If left blank, falls back to the database-configured default for "Ping" or the current channel.
+  - **Permission**: Everyone
 
 ## Verification Commands
-*   **`/verify`** (Slash Command)
-    *   **Description**: Link your Discord account to your RSI Handle using a unique bio checksum. Optionally specify which organisation/affiliate you are verifying for.
-    *   **Usage**: `/verify handle:[Your_RSI_Handle] org:[ORG]`
-    *   **Arguments**:
-        *   `handle`: Your exact Star Citizen RSI Handle.
-        *   `org` *(Optional)*: Symbol of the organisation/affiliate (autocomplete supported).
-    *   **Permission**: Everyone
-*   **`/set_verified_role`** (Slash Command)
-    *   **Description**: Admin command to set the role granted upon successful RSI Verification.
-    *   **Usage**: `/set_verified_role role:@Verified`
-    *   **Arguments**:
-        *   `role`: The role to grant verified users.
-    *   **Permission**: Admin
-*   **`/set_scanz_role`**
-    *   **Description**: Admin command to configure the role that identifies SCANZ members (used for enforcement and audit tagging).
-    *   **Usage**: `/set_scanz_role role:@SCANZ`
-    *   **Permission**: Admin
-*   **`/set_needs_role`**
-    *   **Description**: Admin command to set the role that will be applied to members needing verification.
-    *   **Usage**: `/set_needs_role role:@NeedsVerification`
-    *   **Permission**: Admin
-*   **`/add_org`**
-    *   **Description**: Admin command to add an RSI organisation or affiliate symbol to the configuration.
-    *   **Usage**: `/add_org symbol:SCANZ`
-    *   **Permission**: Admin
-*   **`/remove_org`**
-    *   **Description**: Admin command to remove an organisation symbol.
-    *   **Usage**: `/remove_org symbol:SCANZ`
-    *   **Permission**: Admin
-*   **`/list_orgs`**
-    *   **Description**: Displays the currently configured organisation symbols.
-    *   **Usage**: `/list_orgs`
-    *   **Permission**: Everyone
-*   **`/grant_verified`** (Slash Command)
-    *   **Description**: Admin shortcut to manually apply the verified role and RSI Handle nickname to an already-verified member.
-    *   **Usage**: `/grant_verified member:@SomeUser`
-    *   **Arguments**:
-        *   `member`: The Discord member to apply the verified role and nickname to.
-    *   **Permission**: Admin
-*   **`/manual_verify`** (Slash Command)
-    *   **Description**: Admin command to manually initiate the verification process for a member and an RSI handle. Generates a checksum challenge. You may indicate which organisation this verification is for.
-    *   **Usage**: `/manual_verify member:@SomeUser handle:RSI_Handle org:[ORG]`
-    *   **Arguments**:
-        *   `member`: The Discord member to verify.
-        *   `handle`: The RSI handle to link.
-        *   `org` *(Optional)*: Organisation symbol (autocomplete).
-    *   **Permission**: Admin
-*   **`/export_verified`** (Slash Command)
-    *   **Description**: Admin command to export the entire verification database as a CSV file.
-    *   **Usage**: `/export_verified`
-    *   **Permission**: Admin
-*   **`/search_verified`** (Slash Command)
-    *   **Description**: Admin command to search for a verified member by handle, Discord ID, or mention.
-    *   **Usage**: `/search_verified query:Petri`
-    *   **Arguments**:
-        *   `query`: The RSI handle, Discord ID, or mention to search for.
-    *   **Permission**: Admin
 
-## Roster Monitor (Admin)
-*   **`/roster_audit`** (Slash Command)
-    *   **Description**: Manually triggers a check of all verified members (optionally limited by org) to ensure they are still active in their configured RSI organisation.
-    *   **Permission**: Admin
-*   **`/set_roster_channel`** (Slash Command)
-    *   **Description**: Sets the destination for weekly roster audit reports.
-    *   **Permission**: Admin
-*   **`/org_full_sync`** (Slash Command)
-    *   **Description**: Admin command to perform a comprehensive sync between one or all RSI organisation rosters and the bot's verification database. Identifies unlinked RSI members.
-    *   **Usage**: `/org_full_sync org:[ORG]` (org parameter is optional)
-    *   **Permission**: Admin
+- `**/verify`** (Slash Command)
+  - **Description**: Link your Discord account to your RSI Handle using a unique bio checksum. Optionally specify which organisation/affiliate you are verifying for.
+  - **Usage**: `/verify handle:[Your_RSI_Handle] org:[ORG]`
+  - **Arguments**:
+    - `handle`: Your exact Star Citizen RSI Handle.
+    - `org` *(Optional)*: Symbol of the organisation/affiliate (autocomplete supported).
+  - **Permission**: Everyone
+- `**/set_staff_role`** (Slash Command)
+  - **Description**: *Administrator only.* Set the role that can use all Staff commands (e.g. Custodian). Users with this role or Administrator can use enforce, verification, suggestions, and roster commands.
+  - **Usage**: `/set_staff_role role:@Custodian`
+  - **Permission**: Administrator
+- `**/clear_staff_role`** (Slash Command)
+  - **Description**: *Administrator only.* Clear the staff role so that only users with Administrator can use Staff commands.
+  - **Usage**: `/clear_staff_role`
+  - **Permission**: Administrator
+- `**/set_verified_role`** (Slash Command)
+  - **Description**: Set the role granted upon successful RSI Verification.
+  - **Usage**: `/set_verified_role role:@Verified`
+  - **Arguments**:
+    - `role`: The role to grant verified users.
+  - **Permission**: Staff
+- `**/set_scanz_role`**
+  - **Description**: Configure the role that identifies SCANZ members (used for enforcement and audit tagging).
+  - **Usage**: `/set_scanz_role role:@SCANZ`
+  - **Permission**: Staff
+- `**/set_needs_role`**
+  - **Description**: Set the role that will be applied to members needing verification.
+  - **Usage**: `/set_needs_role role:@NeedsVerification`
+  - **Permission**: Staff
+- `**/add_org`**
+  - **Description**: Add an RSI organisation or affiliate symbol to the configuration.
+  - **Usage**: `/add_org symbol:SCANZ`
+  - **Permission**: Staff
+- `**/remove_org`**
+  - **Description**: Remove an organisation symbol from the configuration.
+  - **Usage**: `/remove_org symbol:SCANZ`
+  - **Permission**: Staff
+- `**/list_orgs`**
+  - **Description**: Displays the currently configured organisation symbols.
+  - **Usage**: `/list_orgs`
+  - **Permission**: Everyone
+- `**/grant_verified`** (Slash Command)
+  - **Description**: Manually apply the verified role and RSI Handle nickname to an already-verified member.
+  - **Usage**: `/grant_verified member:@SomeUser`
+  - **Arguments**:
+    - `member`: The Discord member to apply the verified role and nickname to.
+  - **Permission**: Staff
+- `**/manual_verify`** (Slash Command)
+  - **Description**: Manually initiate the verification process for a member and an RSI handle. Generates a checksum challenge. You may indicate which organisation this verification is for.
+  - **Usage**: `/manual_verify member:@SomeUser handle:RSI_Handle org:[ORG]`
+  - **Arguments**:
+    - `member`: The Discord member to verify.
+    - `handle`: The RSI handle to link.
+    - `org` *(Optional)*: Organisation symbol (autocomplete).
+  - **Permission**: Staff
+- `**/export_verified`** (Slash Command)
+  - **Description**: Export the entire verification database as a CSV file.
+  - **Usage**: `/export_verified`
+  - **Permission**: Staff
+- `**/search_verified`** (Slash Command)
+  - **Description**: Search for a verified member by handle, Discord ID, or mention.
+  - **Usage**: `/search_verified query:Petri`
+  - **Arguments**:
+    - `query`: The RSI handle, Discord ID, or mention to search for.
+  - **Permission**: Staff
+
+## Roster Monitor
+
+- `**/set_roster_channel`** (Slash Command)
+  - **Description**: Set the destination channel for weekly roster audit reports.
+  - **Usage**: `/set_roster_channel channel:#roster-audit`
+  - **Permission**: Staff
+- `**/roster_audit`** (Slash Command)
+  - **Description**: Manually trigger a check of all verified members (optionally limited by org) to ensure they are still active in their configured RSI organisation.
+  - **Usage**: `/roster_audit`
+  - **Permission**: Staff
+- `**/org_full_sync`** (Slash Command)
+  - **Description**: Perform a comprehensive sync between one or all RSI organisation rosters and the bot's verification database. Identifies unlinked RSI members.
+  - **Usage**: `/org_full_sync org:[ORG]` (org parameter is optional)
+  - **Permission**: Staff
 
 ## Suggestion Box
-*   **`/suggestion`** (Slash Command)
-    *   **Description**: Submit feedback or an idea to the staff.
-    *   **Usage**: `/suggestion text:"Your idea" anonymous:True`
-    *   **Arguments**:
-        *   `text`: The content of your suggestion.
-        *   `anonymous`: (Optional) Set to True to hide your name from staff.
-    *   **Permission**: Everyone
-*   **`/set_suggestion_channel`** (Slash Command)
-    *   **Description**: Admin command to set the destination channel for suggestions.
-    *   **Usage**: `/set_suggestion_channel channel:#suggestions-logs`
-    *   **Permission**: Admin
+
+- `**/suggestion`** (Slash Command)
+  - **Description**: Submit feedback or an idea to the staff.
+  - **Usage**: `/suggestion text:"Your idea" anonymous:True`
+  - **Arguments**:
+    - `text`: The content of your suggestion.
+    - `anonymous`: (Optional) Set to True to hide your name from staff.
+  - **Permission**: Everyone
+- `**/set_suggestion_channel`** (Slash Command)
+  - **Description**: Set the destination channel for suggestions.
+  - **Usage**: `/set_suggestion_channel channel:#suggestions-logs`
+  - **Permission**: Staff
 
 ## Utility
-*   **`!ping`**
-    *   **Description**: Checks if the bot is responsive.
-    *   **Usage**: `!ping`
-    *   **Response**: `Pong!`
+
+- `**!ping`**
+  - **Description**: Checks if the bot is responsive.
+  - **Usage**: `!ping`
+  - **Response**: `Pong!`
+  - **Permission**: Everyone
 
 ## Star Citizen Utilities
-*   **`!status`**
-    *   **Description**: Fetches current server status from status.robertsspaceindustries.com.
-    *   **Usage**: `!status`
-*   **`!wiki [term]`**
-    *   **Description**: Generates a search link for the Star Citizen Wiki.
-    *   **Usage**: `!wiki Cutlass Black`
-*   **`!org`**
-    *   **Description**: Displays information and links for SCANZ.
-    *   **Usage**: `!org`
+
+- `**!status`**
+  - **Description**: Fetches current server status from status.robertsspaceindustries.com.
+  - **Usage**: `!status`
+  - **Permission**: Everyone
+- `**!wiki [term]`**
+  - **Description**: Generates a search link for the Star Citizen Wiki.
+  - **Usage**: `!wiki Cutlass Black`
+  - **Permission**: Everyone
+- `**!org`**
+  - **Description**: Displays information and links for SCANZ.
+  - **Usage**: `!org`
+  - **Permission**: Everyone
 
 ## Automated Notifications
-*   **Reboot & Update Alerts**
-    *   **Description**: The bot automatically sends a notification to the designated log channel whenever it reboots or is updated. This message includes the current git branch and the latest commit message for version tracking.
-    *   **Configuration**: Requires `LOG_CHANNEL_ID` in the `.env` file.
+
+- **Reboot & Update Alerts**
+  - **Description**: The bot automatically sends a notification to the designated log channel whenever it reboots or is updated. This message includes the current git branch and the latest commit message for version tracking.
+  - **Configuration**: Requires `LOG_CHANNEL_ID` in the `.env` file.
+

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -67,47 +67,66 @@ class General(commands.Cog):
             name="`/verify`", value="Link your Discord to your RSI Handle using a bio checksum.", inline=False
         )
 
-        # Admin / Utility
+        # Staff/Admin (staff role or Administrator; set with /set_staff_role)
         embed.add_field(
-            name="`/setup_reaction_role`", value="Admin: Create a reaction role message.", inline=False
+            name="`/set_staff_role`",
+            value="Admin only: Set the role that can use staff commands (e.g. Custodian).",
+            inline=False,
         )
         embed.add_field(
-            name="`/enforce_channel`", value="Admin: Toggle strict message enforcement.", inline=False
+            name="`/clear_staff_role`",
+            value="Admin only: Clear staff role so only Administrator can use staff commands.",
+            inline=False,
+        )
+        embed.add_field(
+            name="`/setup_reaction_role`", value="Manage Roles: Create a reaction role message.", inline=False
+        )
+        embed.add_field(
+            name="`/enforce_channel`", value="Staff: Toggle strict message enforcement.", inline=False
         )
         embed.add_field(
             name="`/scanz_format`",
-            value="Admin: Setup allowed Post Types/Game Loops for a channel.",
+            value="Staff: Setup allowed Post Types/Game Loops for a channel.",
             inline=False,
         )
         embed.add_field(
             name="`/set_ping_target`",
-            value="Admin: Map a channel to a specific category for `/ping`.",
+            value="Staff: Map a channel to a specific category for `/ping`.",
             inline=False,
         )
         embed.add_field(
             name="`/scanz_subscriptions`",
-            value="Admin: Post a persistent message to subscribe to ping roles.",
+            value="Staff: Post a persistent message to subscribe to ping roles.",
             inline=False,
         )
         embed.add_field(
             name="`/set_verified_role`",
-            value="Admin: Configure the role given to verified members.",
+            value="Staff: Configure the role given to verified members.",
             inline=False,
         )
         embed.add_field(
             name="`/grant_verified`",
-            value="Admin: Manually apply roles/nick to a verified user.",
+            value="Staff: Manually apply roles/nick to a verified user.",
             inline=False,
         )
         embed.add_field(
-            name="`/manual_verify`", value="Admin: Manually link a member to an RSI handle.", inline=False
+            name="`/manual_verify`", value="Staff: Manually link a member to an RSI handle.", inline=False
         )
         embed.add_field(
-            name="`/export_verified`", value="Admin: Export verification database to CSV.", inline=False
+            name="`/export_verified`", value="Staff: Export verification database to CSV.", inline=False
         )
-        embed.add_field(name="`/search_verified`", value="Admin: Search for a verified member.", inline=False)
+        embed.add_field(name="`/search_verified`", value="Staff: Search for a verified member.", inline=False)
         embed.add_field(
-            name="`/org_full_sync`", value="Admin: Sync RSI roster with bot database.", inline=False
+            name="`/org_full_sync`", value="Staff: Sync RSI roster with bot database.", inline=False
+        )
+        embed.add_field(
+            name="`/set_suggestion_channel`", value="Staff: Set channel where suggestions are sent.", inline=False
+        )
+        embed.add_field(
+            name="`/set_roster_channel`", value="Staff: Set channel for roster audit notifications.", inline=False
+        )
+        embed.add_field(
+            name="`/roster_audit`", value="Staff: Manually check verified members' Org status.", inline=False
         )
 
         # Enforcer Post

--- a/cogs/message_enforcer.py
+++ b/cogs/message_enforcer.py
@@ -8,6 +8,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from utils.checks import has_staff_or_admin
+
 
 def load_config():
     config_path = os.path.join("config", "enforcer_template.json")
@@ -261,9 +263,9 @@ class MessageEnforcer(commands.Cog):
 
     @app_commands.command(
         name="enforce_channel",
-        description="Admin: Toggle strict message enforcement for the current channel.",
+        description="Toggle strict message enforcement for the current channel.",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def enforce_channel(self, interaction: discord.Interaction, enabled: bool):
         """Toggle strict message enforcement for the current channel."""
         self._set_enforced(interaction.channel_id, enabled)
@@ -274,9 +276,9 @@ class MessageEnforcer(commands.Cog):
         )
 
     @app_commands.command(
-        name="scanz_format", description="Admin: Interactive setup for the channel's enforced log format."
+        name="scanz_format", description="Interactive setup for the channel's enforced log format."
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def scanz_format(self, interaction: discord.Interaction):
         """Interactive command to start formatting a channel."""
         if not self._is_enforced(interaction.channel_id):
@@ -292,9 +294,9 @@ class MessageEnforcer(commands.Cog):
         )
 
     @app_commands.command(
-        name="set_ping_target", description="Admin: Set a default target channel for pings."
+        name="set_ping_target", description="Set a default target channel for pings."
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_ping_target(self, interaction: discord.Interaction, channel: discord.TextChannel):
         """Set a default target channel for pings."""
         self._set_post_target("Ping", channel.id)
@@ -304,9 +306,9 @@ class MessageEnforcer(commands.Cog):
 
     @app_commands.command(
         name="scanz_subscriptions",
-        description="Admin: Post the role subscription message in the current channel.",
+        description="Post the role subscription message in the current channel.",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def scanz_subscriptions(self, interaction: discord.Interaction):
         """Post the role subscription message."""
         embed = discord.Embed(

--- a/cogs/roster_monitor.py
+++ b/cogs/roster_monitor.py
@@ -10,6 +10,8 @@ from bs4 import BeautifulSoup
 from discord import app_commands
 from discord.ext import commands, tasks
 
+from utils.checks import has_staff_or_admin
+
 
 async def org_autocomplete(interaction: discord.Interaction, current: str):
     bot = typing.cast(commands.Bot, interaction.client)
@@ -252,9 +254,9 @@ class RosterMonitor(commands.Cog):
             )
 
     @app_commands.command(
-        name="set_roster_channel", description="Admin: Set the channel for roster audit notifications."
+        name="set_roster_channel", description="Set the channel for roster audit notifications."
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_roster_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         self._set_config("roster_audit_channel", str(channel.id))
         await interaction.response.send_message(
@@ -263,9 +265,9 @@ class RosterMonitor(commands.Cog):
 
     @app_commands.command(
         name="roster_audit",
-        description="Admin: Manually trigger a check of all verified members' Org status.",
+        description="Manually trigger a check of all verified members' Org status.",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def roster_audit(self, interaction: discord.Interaction):
         if not self.bot.get_cog("RSIVerification"):
             await interaction.response.send_message(
@@ -277,11 +279,11 @@ class RosterMonitor(commands.Cog):
 
     @app_commands.command(
         name="org_full_sync",
-        description="Admin: Sync one or all RSI Org rosters with the verification database.",
+        description="Sync one or all RSI Org rosters with the verification database.",
     )
     @app_commands.describe(org="The organisation symbol to sync (optional)")
     @app_commands.autocomplete(org=org_autocomplete)
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def org_full_sync(self, interaction: discord.Interaction, org: Optional[str] = None):
         """Perform a full synchronization check between RSI and Discord.
 

--- a/cogs/suggestions.py
+++ b/cogs/suggestions.py
@@ -6,6 +6,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from utils.checks import has_staff_or_admin
+
 
 class Suggestions(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -79,9 +81,9 @@ class Suggestions(commands.Cog):
             conn.commit()
 
     @app_commands.command(
-        name="set_suggestion_channel", description="Admin: Set the channel where suggestions will be sent."
+        name="set_suggestion_channel", description="Set the channel where suggestions will be sent."
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_suggestion_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         """Set the target channel for suggestions."""
         self._set_config(interaction.guild_id, channel.id)

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -11,6 +11,8 @@ from bs4 import BeautifulSoup
 from discord import app_commands
 from discord.ext import commands
 
+from utils.checks import has_staff_or_admin
+
 
 class VerifyNowView(discord.ui.View):
     def __init__(self, cog, handle: str, code: str, org: str | None = None):
@@ -343,10 +345,37 @@ class RSIVerification(commands.Cog):
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @app_commands.command(
-        name="set_verified_role", description="Admin: Set the role granted upon successful RSI Verification."
+        name="set_staff_role",
+        description="Admin only: Set the role that can use staff commands (e.g. enforce, verify, suggestions).",
+    )
+    @app_commands.describe(role="The role that can use staff commands (e.g. Custodian).")
+    @app_commands.default_permissions(administrator=True)
+    async def set_staff_role(self, interaction: discord.Interaction, role: discord.Role):
+        """Set the staff role. Only users with Administrator can run this."""
+        self._set_config("staff_role_id", str(role.id))
+        await interaction.response.send_message(
+            f"✅ Staff role set to {role.mention}. Users with this role or Administrator can use staff commands.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="clear_staff_role",
+        description="Admin only: Clear the staff role so only Administrator can use staff commands.",
+    )
+    @app_commands.default_permissions(administrator=True)
+    async def clear_staff_role(self, interaction: discord.Interaction):
+        """Clear the staff role. Only users with Administrator can run this."""
+        self._set_config("staff_role_id", "")
+        await interaction.response.send_message(
+            "✅ Staff role cleared. Only users with Administrator can use staff commands.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="set_verified_role", description="Set the role granted upon successful RSI Verification."
     )
     @app_commands.describe(role="The role to grant verified users.")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_verified_role(self, interaction: discord.Interaction, role: discord.Role):
         self._set_config("verified_role_id", str(role.id))
         await interaction.response.send_message(
@@ -355,11 +384,11 @@ class RSIVerification(commands.Cog):
 
     @app_commands.command(
         name="manual_verify",
-        description="Admin: Manually initiate verification for a specific member.",
+        description="Manually initiate verification for a specific member.",
     )
     @app_commands.describe(member="The Discord member", handle="The RSI Handle to link")
     @app_commands.describe(org="Organisation symbol for this manual verification")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     @app_commands.autocomplete(org=org_autocomplete)
     async def manual_verify(
         self, interaction: discord.Interaction, member: discord.Member, handle: str, org: str = None
@@ -436,9 +465,9 @@ class RSIVerification(commands.Cog):
 
     @app_commands.command(
         name="export_verified",
-        description="Admin: Export the verification database to a CSV file.",
+        description="Export the verification database to a CSV file.",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def export_verified(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
 
@@ -471,10 +500,10 @@ class RSIVerification(commands.Cog):
 
     @app_commands.command(
         name="search_verified",
-        description="Admin: Search for a verified member by Handle or Discord ID.",
+        description="Search for a verified member by Handle or Discord ID.",
     )
     @app_commands.describe(query="RSI Handle, Discord ID, or Mention")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def search_verified(self, interaction: discord.Interaction, query: str):
         # Cleanup query (mentions, etc)
         clean_query = query.replace("<@", "").replace(">", "").replace("!", "")
@@ -502,10 +531,10 @@ class RSIVerification(commands.Cog):
 
     @app_commands.command(
         name="grant_verified",
-        description="Admin: Manually grant the verified role and RSI nickname to a member.",
+        description="Manually grant the verified role and RSI nickname to a member.",
     )
     @app_commands.describe(member="The Discord member to grant the verified role to.")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def grant_verified(self, interaction: discord.Interaction, member: discord.Member):
         # allow grant to specify org? use any for now
         rsi_handle = self._is_verified(member.id)
@@ -573,9 +602,9 @@ class RSIVerification(commands.Cog):
                 pass
 
     # configuration commands
-    @app_commands.command(name="add_org", description="Admin: add an RSI organisation/affiliate symbol")
+    @app_commands.command(name="add_org", description="Add an RSI organisation/affiliate symbol")
     @app_commands.describe(symbol="The RSI org symbol, e.g. SCANZ")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def add_org(self, interaction: discord.Interaction, symbol: str):
         added = self._add_org(symbol)
         if added:
@@ -587,9 +616,9 @@ class RSIVerification(commands.Cog):
                 f"ℹ️ `{symbol.upper()}` is already configured.", ephemeral=True
             )
 
-    @app_commands.command(name="remove_org", description="Admin: remove an RSI organisation/affiliate symbol")
+    @app_commands.command(name="remove_org", description="Remove an RSI organisation/affiliate symbol")
     @app_commands.describe(symbol="The RSI org symbol to remove")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def remove_org(self, interaction: discord.Interaction, symbol: str):
         removed = self._remove_org(symbol)
         if removed:
@@ -612,19 +641,19 @@ class RSIVerification(commands.Cog):
             await interaction.response.send_message("No organisations have been added yet.", ephemeral=True)
 
     @app_commands.command(
-        name="set_scanz_role", description="Admin: set the role that identifies SCANZ members."
+        name="set_scanz_role", description="Set the role that identifies SCANZ members."
     )
     @app_commands.describe(role="Role that members should have to trigger verification checks")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_scanz_role(self, interaction: discord.Interaction, role: discord.Role):
         self._set_config("scanz_role_id", str(role.id))
         await interaction.response.send_message(f"✅ SCANZ role set to {role.mention}.", ephemeral=True)
 
     @app_commands.command(
-        name="set_needs_role", description="Admin: set role applied to users needing verification."
+        name="set_needs_role", description="Set role applied to users needing verification."
     )
     @app_commands.describe(role="Role to apply when a SCANZ member is not verified")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(has_staff_or_admin)
     async def set_needs_role(self, interaction: discord.Interaction, role: discord.Role):
         self._set_config("needs_role_id", str(role.id))
         await interaction.response.send_message(

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -92,6 +93,25 @@ class ScanzBot(commands.Bot):
 
 
 bot = ScanzBot()
+
+
+@bot.tree.error
+async def on_tree_error(interaction: discord.Interaction, error: app_commands.AppCommandError):
+    """Send a user-friendly message when a permission check fails."""
+    if isinstance(error, app_commands.CheckFailure):
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    "You don't have permission to use this command.", ephemeral=True
+                )
+            else:
+                await interaction.response.send_message(
+                    "You don't have permission to use this command.", ephemeral=True
+                )
+        except discord.NotFound:
+            pass
+        return
+    raise error
 
 
 @bot.command()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils package

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -1,0 +1,28 @@
+"""Shared app_commands checks for SCANZ-BOT."""
+
+import discord
+from discord import app_commands
+
+
+async def has_staff_or_admin(interaction: discord.Interaction) -> bool:
+    """
+    Require the user to have the configured staff role OR Administrator permission.
+    Used for commands that should be available to a custom role (e.g. Custodian)
+    as well as full server admins.
+    If no staff role is configured, only Administrator is allowed (backward compatible).
+    """
+    if not interaction.guild or not interaction.user:
+        return False
+    member = interaction.user
+    if not isinstance(member, discord.Member):
+        return False
+    if member.guild_permissions.administrator:
+        return True
+    ver_cog = interaction.client.get_cog("RSIVerification")
+    if ver_cog and hasattr(ver_cog, "_get_config"):
+        role_id_str = ver_cog._get_config("staff_role_id")
+        if role_id_str:
+            role = interaction.guild.get_role(int(role_id_str))
+            if role and role in member.roles:
+                return True
+    return False


### PR DESCRIPTION
## What does this PR do?

- Add /set_staff_role and /clear_staff_role (Administrator only)
- Staff commands (enforce, verify, suggestions, roster) now accept configured staff role OR Administrator via has_staff_or_admin check
- Add utils/checks.py with shared check; COMMANDS.md updated with permission levels and new commands

## Why is this change needed?

We need to give officers the ability to run commands and have a seperation of concern from other setup commands that should only be done by admins

## Related Issue

Closes #...

## Checklist

- [x] I followed the project style
- [x] I tested my changes
- [x] I updated documentation if needed
